### PR TITLE
fix: 修复Apprise集成问题

### DIFF
--- a/rest_api.py
+++ b/rest_api.py
@@ -145,7 +145,8 @@ async def health() -> Dict[str, Any]:
             push_status = await unified_pusher.get_service_status()
             health_data["services"]["notification"] = {
                 "status": push_status.get("status", "unknown"),
-                "channels_available": push_status.get("channels_available", 0)
+                "apprise_enabled": push_status.get("service_details", {}).get("apprise_enabled", False),
+                "apprise_available": push_status.get("service_details", {}).get("apprise_available", False)
             }
         except Exception as e:
             health_data["services"]["notification"] = {
@@ -277,7 +278,7 @@ async def metrics() -> Dict[str, Any]:
                 "notification_service": {
                     "total_channels": push_status.get("configuration", {}).get("total_channels", 0),
                     "apprise_channels": push_status.get("configuration", {}).get("apprise_channels", 0),
-                    "supported_services": push_status.get("channels_available", 0)
+                    "apprise_enabled": push_status.get("service_details", {}).get("apprise_enabled", False)
                 },
                 "homeassistant": {
                     "enabled": ha_status.get("enabled", False),

--- a/service/notification/unified_pusher.py
+++ b/service/notification/unified_pusher.py
@@ -573,9 +573,13 @@ class UnifiedPusher:
             supported_services = []
             try:
                 import apprise
-
-                apobj = apprise.Apprise()
-                supported_services = list(apobj.schemas())
+                # Apprise 没有 schemas() 方法，我们使用预定义的支持服务列表
+                supported_services = [
+                    'bark', 'tgram', 'mailto', 'wxwork', 'dingding', 'slack', 
+                    'discord', 'teams', 'webhook', 'json', 'form', 'fcm', 
+                    'gotify', 'pushover', 'prowl', 'pushbullet', 'join', 
+                    'notifico', 'pushsafer', 'telegram'
+                ]
             except Exception:
                 pass
 
@@ -630,13 +634,10 @@ class UnifiedPusher:
                     else:
                         total_channels += 1
 
-            # 获取Apprise支持的服务列表
-            supported_services = []
+            # 检查Apprise可用性
             apprise_available = False
             try:
                 import apprise
-                apobj = apprise.Apprise()
-                supported_services = list(apobj.schemas())
                 apprise_available = True
             except Exception as e:
                 logging.warning(f"Apprise不可用: {e}")
@@ -655,12 +656,10 @@ class UnifiedPusher:
 
             return {
                 "status": "healthy" if apprise_status == "healthy" else apprise_status,
-                "channels_available": len(supported_services),
                 "service_details": {
                     "apprise_enabled": self.apprise_enabled,
                     "apprise_available": apprise_available,
                     "apprise_status": apprise_status,
-                    "supported_services_count": len(supported_services),
                 },
                 "configuration": {
                     "total_plates": total_plates,

--- a/service/notification/unified_pusher.py
+++ b/service/notification/unified_pusher.py
@@ -569,24 +569,9 @@ class UnifiedPusher:
             服务状态信息
         """
         try:
-            # 获取Apprise支持的服务列表
-            supported_services = []
-            try:
-                import apprise
-                # Apprise 没有 schemas() 方法，我们使用预定义的支持服务列表
-                supported_services = [
-                    'bark', 'tgram', 'mailto', 'wxwork', 'dingding', 'slack', 
-                    'discord', 'teams', 'webhook', 'json', 'form', 'fcm', 
-                    'gotify', 'pushover', 'prowl', 'pushbullet', 'join', 
-                    'notifico', 'pushsafer', 'telegram'
-                ]
-            except Exception:
-                pass
-
             return {
                 "service_status": {
                     "apprise_enabled": self.apprise_enabled,
-                    "supported_apprise_services": supported_services,
                 },
                 "configuration": {
                     "total_plates": 0,  # 需要从配置中获取
@@ -600,7 +585,6 @@ class UnifiedPusher:
             return {
                 "service_status": {
                     "apprise_enabled": self.apprise_enabled,
-                    "supported_apprise_services": [],
                 },
                 "configuration": {
                     "total_plates": 0,

--- a/service/notification/unified_pusher.py
+++ b/service/notification/unified_pusher.py
@@ -563,34 +563,22 @@ class UnifiedPusher:
 
     def get_status(self) -> Dict[str, Any]:
         """
-        获取推送服务状态
+        获取推送服务状态（同步版本，简单状态）
 
         Returns:
             服务状态信息
         """
         try:
             return {
-                "service_status": {
-                    "apprise_enabled": self.apprise_enabled,
-                },
-                "configuration": {
-                    "total_plates": 0,  # 需要从配置中获取
-                    "apprise_channels": 0,  # 需要从配置中获取
-                    "total_channels": 0,  # 需要从配置中获取
-                },
+                "status": "enabled" if self.apprise_enabled else "disabled",
+                "apprise_enabled": self.apprise_enabled,
             }
-
         except Exception as e:
             logging.error(f"获取服务状态失败: {e}")
             return {
-                "service_status": {
-                    "apprise_enabled": self.apprise_enabled,
-                },
-                "configuration": {
-                    "total_plates": 0,
-                    "apprise_channels": 0,
-                    "total_channels": 0,
-                },
+                "status": "error",
+                "apprise_enabled": self.apprise_enabled,
+                "error": str(e)
             }
 
     async def get_service_status(self) -> Dict[str, Any]:
@@ -649,10 +637,6 @@ class UnifiedPusher:
                     "total_plates": total_plates,
                     "total_channels": total_channels,
                     "apprise_channels": apprise_channels,
-                },
-                "capabilities": {
-                    "priorities": [p.value for p in PushPriority],
-                    "notification_types": ["apprise"],
                 }
             }
 
@@ -661,7 +645,6 @@ class UnifiedPusher:
             return {
                 "status": "error",
                 "error": str(e),
-                "channels_available": 0,
                 "service_details": {
                     "apprise_enabled": self.apprise_enabled,
                     "apprise_available": False,


### PR DESCRIPTION
### 主要改进

1. **简化了 `get_status()` 方法**：
   - 移除了无用的配置统计（这些在 `get_service_status()` 中已经处理）
   - 返回简单的状态信息：`status` 和 `apprise_enabled`
   - 统一了异常处理格式

2. **优化了 `get_service_status()` 方法**：
   - 移除了无用的 `capabilities` 字段
   - 移除了 `channels_available` 字段（已被 `service_details` 替代）
   - 保持了与 `rest_api.py` 调用逻辑的一致性

3. **统一了返回格式**：
   - 健康检查API使用 `service_details.apprise_enabled` 和 `service_details.apprise_available`
   - 指标API使用 `configuration.total_channels`、`configuration.apprise_channels` 和 `service_details.apprise_enabled`
   - 异常处理返回格式一致

### 逻辑合并的好处

- **消除了重复代码**：移除了两个方法中重复的配置统计逻辑
- **统一了数据格式**：确保API返回的数据结构一致
- **简化了维护**：只需要在一个地方维护状态逻辑
- **提高了可读性**：代码结构更清晰，职责更明确

现在 `unified_pusher.py` 和 `rest_api.py` 的行为逻辑已经完全统一，避免了重复和不一致的问题。