### PR TITLE
bugfix: 优化 GitHub Actions 工作流配置，跳过 dependabot 分支的构建以避免权限问题

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -13,6 +13,11 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # 为 dependabot 分支跳过构建，避免权限问题
+    if: ${{ !startsWith(github.actor, 'dependabot') }}
+    permissions:
+      contents: read
+      packages: write
     steps:
     - uses: actions/checkout@v5
 
@@ -46,8 +51,8 @@ jobs:
       run: |
         PLATFORMS=linux/arm64,linux/amd64
         DOCKER_IMAGE=ghcr.io/$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
-        VERSION=${{ env.IMAGE_VERSION }}
-        BRANCH_NAME=${{ env.BRANCH_NAME }}
+        VERSION=${IMAGE_VERSION:-latest}
+        BRANCH_NAME=${BRANCH_NAME:-unknown}
         echo "DOCKER_IMAGE_LOWERCASE=$DOCKER_IMAGE" >> $GITHUB_ENV
 
         if [ "$BRANCH_NAME" = "master" ]; then


### PR DESCRIPTION
优化 GitHub Actions 工作流配置，跳过 dependabot 分支的构建以避免权限问题

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Skips builds on dependabot branches, grants minimal GHCR permissions, and uses fallback defaults for VERSION/BRANCH_NAME during Docker build.
> 
> - **CI/CD** (`.github/workflows/docker-image.yml`):
>   - Skip build for `dependabot` actors via `if: ${{ !startsWith(github.actor, 'dependabot') }}`.
>   - Add workflow `permissions`: `contents: read`, `packages: write`.
>   - Docker build step: use safe defaults `VERSION=${IMAGE_VERSION:-latest}` and `BRANCH_NAME=${BRANCH_NAME:-unknown}`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 04c24785f9ac722aabf58c49061f17c0ae6693e5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->