### PR TITLE
fix: 添加 security-events 权限以修复 CodeQL SARIF 上传问题

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -18,6 +18,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      security-events: write
     steps:
     - uses: actions/checkout@v5
 
@@ -83,4 +84,5 @@ jobs:
       uses: github/codeql-action/upload-sarif@v3
       if: always()
       with:
-        sarif_file: 'trivy-results.sarif' 
+        sarif_file: 'trivy-results.sarif'
+        category: 'trivy-scan' 


### PR DESCRIPTION
- 在 GitHub Actions 工作流中添加 security-events: write 权限
- 为 Trivy 扫描结果添加 category 标识
- 解决 'Resource not accessible by integration' 错误

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Grants `security-events: write` in the Docker image workflow and adds a `category: trivy-scan` to the SARIF upload step.
> 
> - **CI/CD — `.github/workflows/docker-image.yml`**:
>   - **Permissions**: Add `security-events: write` to enable SARIF uploads.
>   - **Security scanning**: Set `category: 'trivy-scan'` on `upload-sarif` for Trivy results.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 956a9565da91042ac606905dbfd5248d4c70474c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->