### PR TITLE
fix: correct Apprise push success rate calculation

### DIFF
--- a/jjz_alert/service/notification/apprise_pusher.py
+++ b/jjz_alert/service/notification/apprise_pusher.py
@@ -13,6 +13,9 @@ from typing import List, Dict, Any, Tuple, Optional
 
 import apprise
 
+# 预编译正则表达式以提高性能
+_TOKEN_PATTERN = re.compile(r"\b[a-zA-Z0-9_-]{20,}\b")
+
 
 class ApprisePusher:
     """Apprise推送器"""
@@ -226,6 +229,22 @@ class ApprisePusher:
                 "url_results": [],
             }
 
+    @staticmethod
+    def _mask_userinfo(userinfo: str) -> str:
+        """
+        遮蔽URL中的userinfo部分（用户名/token）
+
+        Args:
+            userinfo: 原始userinfo字符串
+
+        Returns:
+            遮蔽后的userinfo字符串
+        """
+        if len(userinfo) > 8:
+            return userinfo[:4] + "****"
+        else:
+            return "****"
+
     def _mask_url(self, url: str) -> str:
         """遮蔽URL中的敏感信息"""
         try:
@@ -238,11 +257,7 @@ class ApprisePusher:
                     # 遮蔽host_part中的userinfo（如果存在@符号）
                     if "@" in host_part:
                         userinfo, host = host_part.split("@", 1)
-                        # 遮蔽userinfo，只保留前后几个字符
-                        if len(userinfo) > 8:
-                            masked_userinfo = userinfo[:4] + "****"
-                        else:
-                            masked_userinfo = "****"
+                        masked_userinfo = self._mask_userinfo(userinfo)
                         masked_host_part = f"{masked_userinfo}@{host}"
                     else:
                         masked_host_part = host_part
@@ -257,10 +272,7 @@ class ApprisePusher:
                     # 没有路径时也要遮蔽userinfo
                     if "@" in rest:
                         userinfo, host = rest.split("@", 1)
-                        if len(userinfo) > 8:
-                            masked_userinfo = userinfo[:4] + "****"
-                        else:
-                            masked_userinfo = "****"
+                        masked_userinfo = self._mask_userinfo(userinfo)
                         return f"{scheme}://{masked_userinfo}@{host}"
                     return f"{scheme}://****"
             else:
@@ -294,9 +306,7 @@ class ApprisePusher:
 
             # 尝试遮蔽可能的token/key（通常是长字符串）
             # 匹配可能是token的长字符串（20+字符的字母数字组合）
-            sanitized = re.sub(
-                r"\b[a-zA-Z0-9_-]{20,}\b", lambda m: m.group(0)[:4] + "****", sanitized
-            )
+            sanitized = _TOKEN_PATTERN.sub(lambda m: m.group(0)[:4] + "****", sanitized)
 
             return sanitized
         except Exception:

--- a/jjz_alert/service/notification/apprise_pusher.py
+++ b/jjz_alert/service/notification/apprise_pusher.py
@@ -115,6 +115,7 @@ class ApprisePusher:
             if not valid_url_data:
                 return {
                     "success": False,
+                    "partial_success": False,
                     "error": "没有有效的推送URL",
                     "valid_urls": 0,
                     "invalid_urls": len(invalid_urls),
@@ -135,7 +136,7 @@ class ApprisePusher:
             # 为了获取每个URL的详细推送结果，我们需要单独发送每个URL
             # Apprise的notify()和async_notify()都只返回全局布尔值，无法区分每个URL的状态
             # 使用 asyncio.gather() 并行发送所有URL，保持性能的同时获取准确结果
-            loop = asyncio.get_event_loop()
+            loop = asyncio.get_running_loop()
 
             # 为每个有效URL创建推送任务
             async def send_single_url(
@@ -158,6 +159,7 @@ class ApprisePusher:
                     # 原因：Apprise的notify()只返回全局布尔值，无法区分每个URL的推送状态
                     # 通过为每个URL创建独立实例，我们可以获取准确的单个URL推送结果
                     # 权衡：虽然会有一定资源开销，但换来了准确的错误追踪和部分成功处理能力
+                    # 注：目前功能并发量不会超过10，未来遇到性能瓶颈再优化
                     single_apobj = apprise.Apprise()
                     single_apobj.add(url)
 
@@ -265,6 +267,7 @@ class ApprisePusher:
             logging.error(f"Apprise推送异常: {sanitized_error}")
             return {
                 "success": False,
+                "partial_success": False,
                 "error": sanitized_error,
                 "valid_urls": 0,
                 "invalid_urls": len(urls),
@@ -299,8 +302,6 @@ class ApprisePusher:
                 scheme_part = ""
 
             # 使用正则分割 rest，保留分隔符 @ 和 /
-            import re
-
             # 分割并保留分隔符
             parts = re.split(r"([@/])", rest)
 
@@ -340,7 +341,8 @@ class ApprisePusher:
             sanitized = error_msg
 
             # 遮蔽URL中的敏感部分（如果错误消息包含URL）
-            if url in sanitized:
+            # 注意：必须检查url非空，否则空字符串会匹配所有字符导致消息损坏
+            if url and url in sanitized:
                 sanitized = sanitized.replace(url, self._mask_url(url))
 
             # 尝试遮蔽可能的token/key（通常是长字符串）

--- a/jjz_alert/service/notification/apprise_pusher.py
+++ b/jjz_alert/service/notification/apprise_pusher.py
@@ -14,7 +14,9 @@ from typing import List, Dict, Any, Tuple, Optional
 import apprise
 
 # 预编译正则表达式以提高性能
-_TOKEN_PATTERN = re.compile(r"\b[a-zA-Z0-9_-]{20,}\b")
+# 用于识别可能是token/key的长字符串的最小长度阈值
+TOKEN_MIN_LENGTH = 20
+_TOKEN_PATTERN = re.compile(rf"\b[a-zA-Z0-9_-]{{{TOKEN_MIN_LENGTH},}}\b")
 
 
 class ApprisePusher:
@@ -72,11 +74,13 @@ class ApprisePusher:
             url_results = []
 
             for url in urls:
+                # 预计算遮蔽后的URL，避免多次调用 _mask_url()
+                masked_url = self._mask_url(url)
                 if apobj.add(url):
                     valid_urls.append(url)
                     url_results.append(
                         {
-                            "url": self._mask_url(url),
+                            "url": masked_url,
                             "valid": True,
                             "success": None,  # 将在推送后更新
                         }
@@ -85,13 +89,13 @@ class ApprisePusher:
                     invalid_urls.append(url)
                     url_results.append(
                         {
-                            "url": self._mask_url(url),
+                            "url": masked_url,
                             "valid": False,
                             "success": False,
                             "error": "URL格式无效",
                         }
                     )
-                    logging.warning(f"Apprise URL无效: {self._mask_url(url)}")
+                    logging.warning(f"Apprise URL无效: {masked_url}")
 
             if not valid_urls:
                 return {
@@ -160,12 +164,15 @@ class ApprisePusher:
                 send_single_url(url, self._mask_url(url), body, final_title)
                 for url in valid_urls
             ]
-            push_results = await asyncio.gather(*push_tasks)
+            # 使用 return_exceptions=True 确保一个URL失败不会影响其他URL
+            push_results = await asyncio.gather(*push_tasks, return_exceptions=True)
 
             # 验证结果数量与URL数量匹配（防御性编程）
-            assert len(push_results) == len(
-                valid_urls
-            ), f"推送结果数量({len(push_results)})与有效URL数量({len(valid_urls)})不匹配"
+            # 使用 RuntimeError 而不是 assert，确保在 Python -O 模式下也能捕获错误
+            if len(push_results) != len(valid_urls):
+                raise RuntimeError(
+                    f"推送结果数量({len(push_results)})与有效URL数量({len(valid_urls)})不匹配"
+                )
 
             # 更新url_results中有效URL的推送结果
             # 由于url_results和valid_urls都保持了原始URLs的顺序，可以用索引直接对应
@@ -175,17 +182,29 @@ class ApprisePusher:
                 if url_result["valid"]:
                     # 从push_results中获取对应的结果
                     orig_url = valid_urls[valid_index]
-                    push_success, error_msg = push_results[valid_index]
+                    result = push_results[valid_index]
                     valid_index += 1
 
-                    url_result["success"] = push_success
-                    if error_msg:
-                        # 清理错误消息中的敏感信息
+                    # 处理 gather() 的 return_exceptions=True 可能返回的 Exception 实例
+                    if isinstance(result, Exception):
+                        url_result["success"] = False
+                        error_msg = f"推送异常: {type(result).__name__}: {str(result)}"
                         url_result["error"] = self._sanitize_error_message(
                             error_msg, orig_url
                         )
-                    if push_success:
-                        success_count += 1
+                        logging.error(
+                            f"URL {self._mask_url(orig_url)} 推送失败: {error_msg}"
+                        )
+                    else:
+                        push_success, error_msg = result
+                        url_result["success"] = push_success
+                        if error_msg:
+                            # 清理错误消息中的敏感信息
+                            url_result["error"] = self._sanitize_error_message(
+                                error_msg, orig_url
+                            )
+                        if push_success:
+                            success_count += 1
 
             end_time = datetime.now()
             duration_ms = (end_time - start_time).total_seconds() * 1000

--- a/jjz_alert/service/notification/apprise_pusher.py
+++ b/jjz_alert/service/notification/apprise_pusher.py
@@ -98,34 +98,46 @@ class ApprisePusher:
             logging.debug(f"[APPRISE_DEBUG] 推送参数: {kwargs}")
             logging.debug(f"[APPRISE_DEBUG] 有效URL数量: {len(valid_urls)}")
 
-            # 使用async_notify获取每个URL的详细推送结果
+            # 为了获取每个URL的详细推送结果，我们需要单独发送每个URL
+            # Apprise的notify()和async_notify()都只返回全局布尔值，无法区分每个URL的状态
+            # 单独发送虽然牺牲了一些性能，但能保证准确的成功率统计
             loop = asyncio.get_event_loop()
+            success_count = 0
+            result_index = 0
 
-            # async_notify返回一个列表，包含每个通知服务的推送结果
-            results = await loop.run_in_executor(
-                None,
-                lambda: apobj.async_notify(body, title=final_title)
-            )
+            for url_result in url_results:
+                if url_result["valid"]:
+                    try:
+                        # 为每个URL创建独立的Apprise实例
+                        single_apobj = apprise.Apprise()
+                        single_apobj.add(valid_urls[result_index])
+
+                        # 在线程池中执行推送（notify是同步方法）
+                        single_result = await loop.run_in_executor(
+                            None,
+                            lambda ap=single_apobj: ap.notify(body, title=final_title),
+                        )
+
+                        url_result["success"] = single_result
+                        if single_result:
+                            success_count += 1
+                    except Exception as e:
+                        logging.warning(f"单个URL推送异常: {e}")
+                        url_result["success"] = False
+
+                    result_index += 1
 
             end_time = datetime.now()
             duration_ms = (end_time - start_time).total_seconds() * 1000
 
-            # 更新有效URL的推送结果
-            # async_notify返回的结果列表与添加的URL顺序一致
-            success_count = 0
-            for i, url_result in enumerate([r for r in url_results if r["valid"]]):
-                if i < len(results):
-                    url_result["success"] = results[i]
-                    if results[i]:
-                        success_count += 1
-                else:
-                    url_result["success"] = False
-
             # 整体成功标志：至少有一个URL推送成功
             success = success_count > 0
+            # 部分成功标志：有成功但不是全部成功
+            partial_success = 0 < success_count < len(valid_urls)
 
             result = {
                 "success": success,
+                "partial_success": partial_success,
                 "title": final_title,
                 "body": body,
                 "valid_urls": len(valid_urls),
@@ -140,7 +152,9 @@ class ApprisePusher:
                     f"Apprise推送完成: {success_count}/{len(valid_urls)}个通道成功, 耗时{duration_ms:.0f}ms"
                 )
             else:
-                logging.error(f"Apprise推送失败: {len(valid_urls)}个通道")
+                logging.error(
+                    f"Apprise推送失败: 0/{len(valid_urls)}个通道成功, 耗时{duration_ms:.0f}ms"
+                )
                 result["error"] = "Apprise推送执行失败"
 
             return result

--- a/jjz_alert/service/notification/apprise_pusher.py
+++ b/jjz_alert/service/notification/apprise_pusher.py
@@ -100,32 +100,55 @@ class ApprisePusher:
 
             # 为了获取每个URL的详细推送结果，我们需要单独发送每个URL
             # Apprise的notify()和async_notify()都只返回全局布尔值，无法区分每个URL的状态
-            # 单独发送虽然牺牲了一些性能，但能保证准确的成功率统计
+            # 使用 asyncio.gather() 并行发送所有URL，保持性能的同时获取准确结果
             loop = asyncio.get_event_loop()
-            success_count = 0
-            result_index = 0
 
+            # 为每个有效URL创建推送任务
+            async def send_single_url(
+                url: str, masked_url: str, msg_body: str, msg_title: str
+            ):
+                """
+                发送单个URL的推送
+
+                Returns:
+                    tuple: (success: bool, error_msg: str or None)
+                """
+                try:
+                    # 为每个URL创建独立的Apprise实例
+                    single_apobj = apprise.Apprise()
+                    single_apobj.add(url)
+
+                    # 在线程池中执行推送（notify是同步方法）
+                    # 显式捕获参数避免闭包问题
+                    push_result = await loop.run_in_executor(
+                        None,
+                        lambda: single_apobj.notify(msg_body, title=msg_title),
+                    )
+                    return (push_result, None)
+                except Exception as exc:
+                    error_msg = f"推送异常: {str(exc)}"
+                    logging.warning(f"URL {masked_url} {error_msg}")
+                    return (False, error_msg)
+
+            # 为每个有效URL创建推送任务，同时传递遮蔽后的URL用于日志
+            push_tasks = [
+                send_single_url(url, self._mask_url(url), body, final_title)
+                for url in valid_urls
+            ]
+            push_results = await asyncio.gather(*push_tasks)
+
+            # 更新url_results中有效URL的推送结果
+            # 使用enumerate避免手动索引追踪
+            success_count = 0
+            valid_results_iter = iter(push_results)
             for url_result in url_results:
                 if url_result["valid"]:
-                    try:
-                        # 为每个URL创建独立的Apprise实例
-                        single_apobj = apprise.Apprise()
-                        single_apobj.add(valid_urls[result_index])
-
-                        # 在线程池中执行推送（notify是同步方法）
-                        single_result = await loop.run_in_executor(
-                            None,
-                            lambda ap=single_apobj: ap.notify(body, title=final_title),
-                        )
-
-                        url_result["success"] = single_result
-                        if single_result:
-                            success_count += 1
-                    except Exception as e:
-                        logging.warning(f"单个URL推送异常: {e}")
-                        url_result["success"] = False
-
-                    result_index += 1
+                    push_success, error_msg = next(valid_results_iter)
+                    url_result["success"] = push_success
+                    if error_msg:
+                        url_result["error"] = error_msg
+                    if push_success:
+                        success_count += 1
 
             end_time = datetime.now()
             duration_ms = (end_time - start_time).total_seconds() * 1000

--- a/jjz_alert/service/notification/apprise_pusher.py
+++ b/jjz_alert/service/notification/apprise_pusher.py
@@ -98,17 +98,31 @@ class ApprisePusher:
             logging.debug(f"[APPRISE_DEBUG] 推送参数: {kwargs}")
             logging.debug(f"[APPRISE_DEBUG] 有效URL数量: {len(valid_urls)}")
 
-            # 在线程池中执行同步的Apprise推送
+            # 使用async_notify获取每个URL的详细推送结果
             loop = asyncio.get_event_loop()
-            success = await loop.run_in_executor(None, apobj.notify, body, final_title)
+
+            # async_notify返回一个列表，包含每个通知服务的推送结果
+            results = await loop.run_in_executor(
+                None,
+                lambda: apobj.async_notify(body, title=final_title)
+            )
 
             end_time = datetime.now()
             duration_ms = (end_time - start_time).total_seconds() * 1000
 
             # 更新有效URL的推送结果
-            for url_result in url_results:
-                if url_result["valid"]:
-                    url_result["success"] = success
+            # async_notify返回的结果列表与添加的URL顺序一致
+            success_count = 0
+            for i, url_result in enumerate([r for r in url_results if r["valid"]]):
+                if i < len(results):
+                    url_result["success"] = results[i]
+                    if results[i]:
+                        success_count += 1
+                else:
+                    url_result["success"] = False
+
+            # 整体成功标志：至少有一个URL推送成功
+            success = success_count > 0
 
             result = {
                 "success": success,
@@ -123,7 +137,7 @@ class ApprisePusher:
 
             if success:
                 logging.info(
-                    f"Apprise推送成功: {len(valid_urls)}个通道, 耗时{duration_ms:.0f}ms"
+                    f"Apprise推送完成: {success_count}/{len(valid_urls)}个通道成功, 耗时{duration_ms:.0f}ms"
                 )
             else:
                 logging.error(f"Apprise推送失败: {len(valid_urls)}个通道")

--- a/jjz_alert/service/notification/apprise_pusher.py
+++ b/jjz_alert/service/notification/apprise_pusher.py
@@ -69,15 +69,30 @@ class ApprisePusher:
             apobj = apprise.Apprise()
 
             # 添加URL配置并记录结果（基于本地实例）
-            valid_urls = []
+            # 存储 (url, masked_url) 元组以避免重复调用 _mask_url()
+            valid_url_data = []  # List[(str, str)]
             invalid_urls = []
             url_results = []
 
             for url in urls:
+                # 添加输入验证：跳过 None 或空字符串
+                if not url or not isinstance(url, str):
+                    logging.warning(f"跳过无效URL类型: {type(url).__name__}")
+                    invalid_urls.append(url if url else "<empty>")
+                    url_results.append(
+                        {
+                            "url": "****",
+                            "valid": False,
+                            "success": False,
+                            "error": "URL为空或类型无效",
+                        }
+                    )
+                    continue
+
                 # 预计算遮蔽后的URL，避免多次调用 _mask_url()
                 masked_url = self._mask_url(url)
                 if apobj.add(url):
-                    valid_urls.append(url)
+                    valid_url_data.append((url, masked_url))
                     url_results.append(
                         {
                             "url": masked_url,
@@ -97,7 +112,7 @@ class ApprisePusher:
                     )
                     logging.warning(f"Apprise URL无效: {masked_url}")
 
-            if not valid_urls:
+            if not valid_url_data:
                 return {
                     "success": False,
                     "error": "没有有效的推送URL",
@@ -115,7 +130,7 @@ class ApprisePusher:
                 f"[APPRISE_DEBUG] 推送内容: {body[:100]}..."
             )  # 只显示前100字符
             logging.debug(f"[APPRISE_DEBUG] 推送参数: {kwargs}")
-            logging.debug(f"[APPRISE_DEBUG] 有效URL数量: {len(valid_urls)}")
+            logging.debug(f"[APPRISE_DEBUG] 有效URL数量: {len(valid_url_data)}")
 
             # 为了获取每个URL的详细推送结果，我们需要单独发送每个URL
             # Apprise的notify()和async_notify()都只返回全局布尔值，无法区分每个URL的状态
@@ -156,32 +171,36 @@ class ApprisePusher:
                 except Exception as exc:
                     # 记录异常类型和详细信息，包含堆栈跟踪便于调试
                     error_msg = f"推送异常: {type(exc).__name__}: {str(exc)}"
-                    logging.warning(f"URL {masked_url} {error_msg}", exc_info=True)
+                    # 清理日志中的敏感信息（URL已经遮蔽，但异常信息可能包含敏感数据）
+                    sanitized_log_msg = self._sanitize_error_message(error_msg, url)
+                    logging.warning(
+                        f"URL {masked_url} {sanitized_log_msg}", exc_info=True
+                    )
                     return (False, error_msg)
 
-            # 为每个有效URL创建推送任务
+            # 为每个有效URL创建推送任务，使用缓存的 masked_url
             push_tasks = [
-                send_single_url(url, self._mask_url(url), body, final_title)
-                for url in valid_urls
+                send_single_url(url, masked_url, body, final_title)
+                for url, masked_url in valid_url_data
             ]
             # 使用 return_exceptions=True 确保一个URL失败不会影响其他URL
             push_results = await asyncio.gather(*push_tasks, return_exceptions=True)
 
             # 验证结果数量与URL数量匹配（防御性编程）
             # 使用 RuntimeError 而不是 assert，确保在 Python -O 模式下也能捕获错误
-            if len(push_results) != len(valid_urls):
+            if len(push_results) != len(valid_url_data):
                 raise RuntimeError(
-                    f"推送结果数量({len(push_results)})与有效URL数量({len(valid_urls)})不匹配"
+                    f"推送结果数量({len(push_results)})与有效URL数量({len(valid_url_data)})不匹配"
                 )
 
             # 更新url_results中有效URL的推送结果
-            # 由于url_results和valid_urls都保持了原始URLs的顺序，可以用索引直接对应
+            # 由于url_results和valid_url_data都保持了原始URLs的顺序，可以用索引直接对应
             success_count = 0
             valid_index = 0
             for url_result in url_results:
                 if url_result["valid"]:
-                    # 从push_results中获取对应的结果
-                    orig_url = valid_urls[valid_index]
+                    # 从valid_url_data和push_results中获取对应的结果
+                    orig_url, cached_masked_url = valid_url_data[valid_index]
                     result = push_results[valid_index]
                     valid_index += 1
 
@@ -189,11 +208,13 @@ class ApprisePusher:
                     if isinstance(result, Exception):
                         url_result["success"] = False
                         error_msg = f"推送异常: {type(result).__name__}: {str(result)}"
-                        url_result["error"] = self._sanitize_error_message(
+                        sanitized_error = self._sanitize_error_message(
                             error_msg, orig_url
                         )
+                        url_result["error"] = sanitized_error
+                        # 清理日志中的敏感信息
                         logging.error(
-                            f"URL {self._mask_url(orig_url)} 推送失败: {error_msg}"
+                            f"URL {cached_masked_url} 推送失败: {sanitized_error}"
                         )
                     else:
                         push_success, error_msg = result
@@ -212,14 +233,14 @@ class ApprisePusher:
             # 整体成功标志：至少有一个URL推送成功
             success = success_count > 0
             # 部分成功标志：有成功但不是全部成功
-            partial_success = 0 < success_count < len(valid_urls)
+            partial_success = 0 < success_count < len(valid_url_data)
 
             result = {
                 "success": success,
                 "partial_success": partial_success,
                 "title": final_title,
                 "body": body,
-                "valid_urls": len(valid_urls),
+                "valid_urls": len(valid_url_data),
                 "invalid_urls": len(invalid_urls),
                 "duration_ms": round(duration_ms, 2),
                 "timestamp": end_time.isoformat(),
@@ -228,77 +249,73 @@ class ApprisePusher:
 
             if success:
                 logging.info(
-                    f"Apprise推送完成: {success_count}/{len(valid_urls)}个通道成功, 耗时{duration_ms:.0f}ms"
+                    f"Apprise推送完成: {success_count}/{len(valid_url_data)}个通道成功, 耗时{duration_ms:.0f}ms"
                 )
             else:
                 logging.error(
-                    f"Apprise推送失败: 0/{len(valid_urls)}个通道成功, 耗时{duration_ms:.0f}ms"
+                    f"Apprise推送失败: 0/{len(valid_url_data)}个通道成功, 耗时{duration_ms:.0f}ms"
                 )
                 result["error"] = "Apprise推送执行失败"
 
             return result
 
         except Exception as e:
-            logging.error(f"Apprise推送异常: {e}")
+            # 清理顶层异常消息中的敏感信息
+            sanitized_error = self._sanitize_error_message(str(e), "")
+            logging.error(f"Apprise推送异常: {sanitized_error}")
             return {
                 "success": False,
-                "error": str(e),
+                "error": sanitized_error,
                 "valid_urls": 0,
                 "invalid_urls": len(urls),
                 "url_results": [],
             }
 
-    @staticmethod
-    def _mask_userinfo(userinfo: str) -> str:
-        """
-        遮蔽URL中的userinfo部分（用户名/token）
-
-        Args:
-            userinfo: 原始userinfo字符串
-
-        Returns:
-            遮蔽后的userinfo字符串
-        """
-        if len(userinfo) > 8:
-            return userinfo[:4] + "****"
-        else:
-            return "****"
-
     def _mask_url(self, url: str) -> str:
-        """遮蔽URL中的敏感信息"""
+        """
+        遮蔽URL中的敏感信息
+
+        策略：
+        1. scheme (://之前) 保持完整
+        2. 其余部分用 @ 和 / 分隔，对每个部分：
+           - 长度 >= 3：显示前3字符 + "****"
+           - 长度 < 3：全部显示为 "****"
+
+        Examples:
+            "bark://token@api.day.app/device" -> "bark://tok****@api****/dev****"
+            "smtp://ab@x/y" -> "smtp://****@****/****"
+        """
         try:
-            # 简单的URL遮蔽，隐藏token等敏感信息
+            if not url or not isinstance(url, str):
+                return "****"
+
+            # 提取 scheme
             if "://" in url:
                 scheme, rest = url.split("://", 1)
-                if "/" in rest:
-                    host_part, path_part = rest.split("/", 1)
-
-                    # 遮蔽host_part中的userinfo（如果存在@符号）
-                    if "@" in host_part:
-                        # 使用 rsplit 从右边分割，确保正确处理密码中包含 @ 的情况
-                        # 例如：user:p@ssword@smtp.example.com 应该分成 user:p@ssword 和 smtp.example.com
-                        userinfo, host = host_part.rsplit("@", 1)
-                        masked_userinfo = self._mask_userinfo(userinfo)
-                        masked_host_part = f"{masked_userinfo}@{host}"
-                    else:
-                        masked_host_part = host_part
-
-                    # 只显示前几个字符
-                    if len(path_part) > 8:
-                        masked_path = path_part[:4] + "****" + path_part[-4:]
-                    else:
-                        masked_path = "****"
-                    return f"{scheme}://{masked_host_part}/{masked_path}"
-                else:
-                    # 没有路径时也要遮蔽userinfo
-                    if "@" in rest:
-                        # 使用 rsplit 从右边分割，确保正确处理密码中包含 @ 的情况
-                        userinfo, host = rest.rsplit("@", 1)
-                        masked_userinfo = self._mask_userinfo(userinfo)
-                        return f"{scheme}://{masked_userinfo}@{host}"
-                    return f"{scheme}://****"
+                scheme_part = scheme + "://"
             else:
-                return "****"
+                # 没有 scheme，整个URL遮蔽
+                rest = url
+                scheme_part = ""
+
+            # 使用正则分割 rest，保留分隔符 @ 和 /
+            import re
+
+            # 分割并保留分隔符
+            parts = re.split(r"([@/])", rest)
+
+            # 遮蔽每个非分隔符部分
+            masked_parts = []
+            for part in parts:
+                if part in ["@", "/"]:  # 分隔符保持原样
+                    masked_parts.append(part)
+                elif part:  # 非空部分需要遮蔽
+                    if len(part) >= 3:
+                        masked_parts.append(part[:3] + "****")
+                    else:
+                        masked_parts.append("****")
+
+            return scheme_part + "".join(masked_parts)
         except Exception:
             return "****"
 

--- a/jjz_alert/service/notification/apprise_pusher.py
+++ b/jjz_alert/service/notification/apprise_pusher.py
@@ -44,7 +44,17 @@ class ApprisePusher:
             **kwargs: 其他参数
 
         Returns:
-            推送结果
+            推送结果字典，包含以下字段：
+            - success (bool): 整体是否成功（至少一个通道成功则为True）
+            - partial_success (bool): 是否部分成功（有成功但不是全部成功）
+            - title (str): 推送标题
+            - body (str): 推送内容
+            - valid_urls (int): 有效URL数量
+            - invalid_urls (int): 无效URL数量
+            - duration_ms (float): 推送耗时（毫秒）
+            - timestamp (str): 完成时间（ISO格式）
+            - url_results (List[Dict]): 每个URL的推送结果详情
+            - error (str, optional): 错误信息（如果有）
         """
         try:
             # 使用传入的标题
@@ -157,15 +167,21 @@ class ApprisePusher:
             )
             for url_result in url_results:
                 if url_result["valid"]:
-                    orig_url, (push_success, error_msg) = next(valid_results_iter)
-                    url_result["success"] = push_success
-                    if error_msg:
-                        # 清理错误消息中的敏感信息
-                        url_result["error"] = self._sanitize_error_message(
-                            error_msg, orig_url
-                        )
-                    if push_success:
-                        success_count += 1
+                    try:
+                        orig_url, (push_success, error_msg) = next(valid_results_iter)
+                        url_result["success"] = push_success
+                        if error_msg:
+                            # 清理错误消息中的敏感信息
+                            url_result["error"] = self._sanitize_error_message(
+                                error_msg, orig_url
+                            )
+                        if push_success:
+                            success_count += 1
+                    except StopIteration:
+                        # 防御性编程：处理迭代器耗尽的边缘情况
+                        logging.error("迭代器耗尽：valid URL数量与推送结果不匹配")
+                        url_result["success"] = False
+                        url_result["error"] = "内部错误：推送结果处理异常"
 
             end_time = datetime.now()
             duration_ms = (end_time - start_time).total_seconds() * 1000
@@ -217,13 +233,34 @@ class ApprisePusher:
                 scheme, rest = url.split("://", 1)
                 if "/" in rest:
                     host_part, path_part = rest.split("/", 1)
+
+                    # 遮蔽host_part中的userinfo（如果存在@符号）
+                    if "@" in host_part:
+                        userinfo, host = host_part.split("@", 1)
+                        # 遮蔽userinfo，只保留前后几个字符
+                        if len(userinfo) > 8:
+                            masked_userinfo = userinfo[:4] + "****"
+                        else:
+                            masked_userinfo = "****"
+                        masked_host_part = f"{masked_userinfo}@{host}"
+                    else:
+                        masked_host_part = host_part
+
                     # 只显示前几个字符
                     if len(path_part) > 8:
                         masked_path = path_part[:4] + "****" + path_part[-4:]
                     else:
                         masked_path = "****"
-                    return f"{scheme}://{host_part}/{masked_path}"
+                    return f"{scheme}://{masked_host_part}/{masked_path}"
                 else:
+                    # 没有路径时也要遮蔽userinfo
+                    if "@" in rest:
+                        userinfo, host = rest.split("@", 1)
+                        if len(userinfo) > 8:
+                            masked_userinfo = userinfo[:4] + "****"
+                        else:
+                            masked_userinfo = "****"
+                        return f"{scheme}://{masked_userinfo}@{host}"
                     return f"{scheme}://****"
             else:
                 return "****"
@@ -242,6 +279,12 @@ class ApprisePusher:
             清理后的错误消息
         """
         try:
+            # 处理None和空字符串
+            if error_msg is None:
+                return "推送异常（错误详情已隐藏）"
+            if not error_msg:
+                return error_msg  # 返回空字符串
+
             sanitized = error_msg
 
             # 遮蔽URL中的敏感部分（如果错误消息包含URL）

--- a/jjz_alert/service/notification/apprise_pusher.py
+++ b/jjz_alert/service/notification/apprise_pusher.py
@@ -103,8 +103,7 @@ class ApprisePusher:
 
             # async_notify返回一个列表，包含每个通知服务的推送结果
             results = await loop.run_in_executor(
-                None,
-                lambda: apobj.async_notify(body, title=final_title)
+                None, lambda: apobj.async_notify(body, title=final_title)
             )
 
             end_time = datetime.now()

--- a/jjz_alert/service/notification/apprise_pusher.py
+++ b/jjz_alert/service/notification/apprise_pusher.py
@@ -275,7 +275,9 @@ class ApprisePusher:
 
                     # 遮蔽host_part中的userinfo（如果存在@符号）
                     if "@" in host_part:
-                        userinfo, host = host_part.split("@", 1)
+                        # 使用 rsplit 从右边分割，确保正确处理密码中包含 @ 的情况
+                        # 例如：user:p@ssword@smtp.example.com 应该分成 user:p@ssword 和 smtp.example.com
+                        userinfo, host = host_part.rsplit("@", 1)
                         masked_userinfo = self._mask_userinfo(userinfo)
                         masked_host_part = f"{masked_userinfo}@{host}"
                     else:
@@ -290,7 +292,8 @@ class ApprisePusher:
                 else:
                     # 没有路径时也要遮蔽userinfo
                     if "@" in rest:
-                        userinfo, host = rest.split("@", 1)
+                        # 使用 rsplit 从右边分割，确保正确处理密码中包含 @ 的情况
+                        userinfo, host = rest.rsplit("@", 1)
                         masked_userinfo = self._mask_userinfo(userinfo)
                         return f"{scheme}://{masked_userinfo}@{host}"
                     return f"{scheme}://****"

--- a/jjz_alert/service/notification/apprise_pusher.py
+++ b/jjz_alert/service/notification/apprise_pusher.py
@@ -152,7 +152,9 @@ class ApprisePusher:
             # 更新url_results中有效URL的推送结果
             # 使用迭代器避免手动索引追踪
             success_count = 0
-            valid_results_iter = iter(zip([url for url, _ in push_tasks_with_urls], push_results))
+            valid_results_iter = iter(
+                zip([url for url, _ in push_tasks_with_urls], push_results)
+            )
             for url_result in url_results:
                 if url_result["valid"]:
                     orig_url, (push_success, error_msg) = next(valid_results_iter)

--- a/jjz_alert/service/notification/apprise_pusher.py
+++ b/jjz_alert/service/notification/apprise_pusher.py
@@ -133,6 +133,9 @@ class ApprisePusher:
                 """
                 try:
                     # 为每个URL创建独立的Apprise实例
+                    # 原因：Apprise的notify()只返回全局布尔值，无法区分每个URL的推送状态
+                    # 通过为每个URL创建独立实例，我们可以获取准确的单个URL推送结果
+                    # 权衡：虽然会有一定资源开销，但换来了准确的错误追踪和部分成功处理能力
                     single_apobj = apprise.Apprise()
                     single_apobj.add(url)
 
@@ -149,39 +152,37 @@ class ApprisePusher:
                     logging.warning(f"URL {masked_url} {error_msg}", exc_info=True)
                     return (False, error_msg)
 
-            # 为每个有效URL创建推送任务，同时传递遮蔽后的URL用于日志
-            # 同时保留原始URL列表用于错误消息清理
-            push_tasks_with_urls = [
-                (url, send_single_url(url, self._mask_url(url), body, final_title))
+            # 为每个有效URL创建推送任务
+            push_tasks = [
+                send_single_url(url, self._mask_url(url), body, final_title)
                 for url in valid_urls
             ]
-            push_results = await asyncio.gather(
-                *[task for _, task in push_tasks_with_urls]
-            )
+            push_results = await asyncio.gather(*push_tasks)
+
+            # 验证结果数量与URL数量匹配（防御性编程）
+            assert len(push_results) == len(
+                valid_urls
+            ), f"推送结果数量({len(push_results)})与有效URL数量({len(valid_urls)})不匹配"
 
             # 更新url_results中有效URL的推送结果
-            # 使用迭代器避免手动索引追踪
+            # 由于url_results和valid_urls都保持了原始URLs的顺序，可以用索引直接对应
             success_count = 0
-            valid_results_iter = iter(
-                zip([url for url, _ in push_tasks_with_urls], push_results)
-            )
+            valid_index = 0
             for url_result in url_results:
                 if url_result["valid"]:
-                    try:
-                        orig_url, (push_success, error_msg) = next(valid_results_iter)
-                        url_result["success"] = push_success
-                        if error_msg:
-                            # 清理错误消息中的敏感信息
-                            url_result["error"] = self._sanitize_error_message(
-                                error_msg, orig_url
-                            )
-                        if push_success:
-                            success_count += 1
-                    except StopIteration:
-                        # 防御性编程：处理迭代器耗尽的边缘情况
-                        logging.error("迭代器耗尽：valid URL数量与推送结果不匹配")
-                        url_result["success"] = False
-                        url_result["error"] = "内部错误：推送结果处理异常"
+                    # 从push_results中获取对应的结果
+                    orig_url = valid_urls[valid_index]
+                    push_success, error_msg = push_results[valid_index]
+                    valid_index += 1
+
+                    url_result["success"] = push_success
+                    if error_msg:
+                        # 清理错误消息中的敏感信息
+                        url_result["error"] = self._sanitize_error_message(
+                            error_msg, orig_url
+                        )
+                    if push_success:
+                        success_count += 1
 
             end_time = datetime.now()
             duration_ms = (end_time - start_time).total_seconds() * 1000

--- a/tests/unit/service/test_apprise_pusher.py
+++ b/tests/unit/service/test_apprise_pusher.py
@@ -244,11 +244,16 @@ class TestApprisePusher:
         url = "bark://test_key@api.day.app/test_path"
         masked = pusher._mask_url(url)
 
+        # 验证 scheme 保留
         assert "bark://" in masked
-        # URL遮蔽只遮蔽路径部分，host部分（包括test_key）仍然可见
-        assert "api.day.app" in masked
-        assert "****" in masked
-        # 路径部分被遮蔽
+        # 验证所有部分被遮蔽（显示前3字符 + ****）
+        assert "tes****" in masked  # test_key -> tes****
+        assert "api****" in masked  # api.day.app -> api****
+        # 验证分隔符保留
+        assert "@" in masked
+        assert "/" in masked
+        # 验证敏感信息被遮蔽
+        assert "test_key" not in masked
         assert "test_path" not in masked
 
     def test_mask_url_short_path(self):
@@ -275,7 +280,9 @@ class TestApprisePusher:
         url = "invalid_url"
         masked = pusher._mask_url(url)
 
-        assert masked == "****"
+        # 无 scheme 的 URL，整个作为一个部分遮蔽
+        # "invalid_url" 长度 >= 3，显示前3字符 + ****
+        assert masked == "inv****"
 
     def test_mask_url_exception(self):
         """测试URL遮蔽 - 异常情况"""
@@ -295,14 +302,16 @@ class TestApprisePusher:
 
         # 验证 scheme 保留
         assert "smtp://" in masked
-        # 验证 host 正确识别（不应包含密码的一部分）
-        assert "smtp.example.com" in masked
-        # 验证 userinfo 被遮蔽
+        # 验证所有部分被遮蔽（新的简化逻辑按 @ 和 / 分隔，每部分都遮蔽）
         assert "****" in masked
-        # 验证密码中的 @ 不会导致错误的 host 识别
-        assert "ssw0rd@smtp.example.com" not in masked
-        # 验证整个 userinfo（user:p@ssw0rd）被遮蔽
+        # 验证 @ 分隔符保留
+        assert masked.count("@") == 2  # 保留2个@符号
+        # 验证密码不泄露
         assert "p@ssw0rd" not in masked
+        assert "ssw0rd" not in masked
+        # 预期结果类似: smtp://use****@ssw****@smt****/pat****
+        assert "use****" in masked  # user:p -> use****（前3字符+****）
+        assert "ssw****" in masked  # ssw0rd -> ssw****
 
     def test_mask_url_with_at_in_password_no_path(self):
         """测试URL遮蔽 - 密码包含@符号且无路径"""
@@ -310,10 +319,15 @@ class TestApprisePusher:
         url = "smtp://user:p@ssw0rd@smtp.example.com"
         masked = pusher._mask_url(url)
 
+        # 验证 scheme 保留
         assert "smtp://" in masked
-        assert "smtp.example.com" in masked
+        # 验证所有部分被遮蔽
         assert "****" in masked
+        # 验证 @ 分隔符保留
+        assert masked.count("@") == 2
+        # 验证密码不泄露
         assert "p@ssw0rd" not in masked
+        assert "ssw0rd" not in masked
 
     def test_sanitize_error_message_with_url(self):
         """测试错误消息清理 - 包含URL"""

--- a/tests/unit/service/test_apprise_pusher.py
+++ b/tests/unit/service/test_apprise_pusher.py
@@ -209,7 +209,9 @@ class TestApprisePusher:
 
             with patch("asyncio.get_event_loop") as mock_loop:
                 mock_loop_instance = Mock()
-                mock_loop_instance.run_in_executor = AsyncMock(return_value=False)  # 推送失败
+                mock_loop_instance.run_in_executor = AsyncMock(
+                    return_value=False
+                )  # 推送失败
                 mock_loop.return_value = mock_loop_instance
 
                 result = await pusher.send_notification(urls, title, body)

--- a/tests/unit/service/test_apprise_pusher.py
+++ b/tests/unit/service/test_apprise_pusher.py
@@ -285,6 +285,44 @@ class TestApprisePusher:
 
         assert masked == "****"
 
+    def test_sanitize_error_message_with_url(self):
+        """测试错误消息清理 - 包含URL"""
+        pusher = ApprisePusher()
+        url = "bark://secret_token_12345@api.day.app/path"
+        error_msg = f"Failed to send to {url}"
+        sanitized = pusher._sanitize_error_message(error_msg, url)
+
+        # URL应该被遮蔽
+        assert "secret_token_12345" not in sanitized
+        assert "****" in sanitized
+        assert "Failed to send" in sanitized
+
+    def test_sanitize_error_message_with_long_token(self):
+        """测试错误消息清理 - 包含长token"""
+        pusher = ApprisePusher()
+        # 创建一个包含长token的错误消息（20+字符）
+        error_msg = "Auth failed: token_abcdefghijklmnopqrstuvwxyz123456"
+        sanitized = pusher._sanitize_error_message(error_msg, "bark://test")
+
+        # 长字符串应该被遮蔽
+        assert "abcdefghijklmnopqrstuvwxyz123456" not in sanitized
+        assert "toke****" in sanitized
+        assert "Auth failed" in sanitized
+
+    def test_sanitize_error_message_exception_handling(self):
+        """测试错误消息清理 - 异常处理"""
+        pusher = ApprisePusher()
+        # 测试None输入
+        result = pusher._sanitize_error_message(None, "test")
+        assert "错误详情已隐藏" in result
+
+    def test_sanitize_error_message_empty_string(self):
+        """测试错误消息清理 - 空字符串"""
+        pusher = ApprisePusher()
+        result = pusher._sanitize_error_message("", "bark://test")
+        # 空字符串应该正常返回
+        assert result == ""
+
     def test_validate_urls_success(self):
         """测试URL验证成功"""
         pusher = ApprisePusher()

--- a/tests/unit/service/test_apprise_pusher.py
+++ b/tests/unit/service/test_apprise_pusher.py
@@ -60,12 +60,12 @@ class TestApprisePusher:
         ) as mock_apprise:
             mock_instance = Mock()
             mock_instance.add.return_value = True
-            mock_instance.notify.return_value = True
+            mock_instance.async_notify.return_value = [True]  # 返回列表
             mock_apprise.Apprise.return_value = mock_instance
 
             with patch("asyncio.get_event_loop") as mock_loop:
                 mock_loop_instance = Mock()
-                mock_loop_instance.run_in_executor = AsyncMock(return_value=True)
+                mock_loop_instance.run_in_executor = AsyncMock(return_value=[True])
                 mock_loop.return_value = mock_loop_instance
 
                 result = await pusher.send_notification(urls, title, body)
@@ -111,12 +111,12 @@ class TestApprisePusher:
         ) as mock_apprise:
             mock_instance = Mock()
             mock_instance.add.side_effect = [True, False]
-            mock_instance.notify.return_value = True
+            mock_instance.async_notify.return_value = [True]  # 只有一个有效URL
             mock_apprise.Apprise.return_value = mock_instance
 
             with patch("asyncio.get_event_loop") as mock_loop:
                 mock_loop_instance = Mock()
-                mock_loop_instance.run_in_executor = AsyncMock(return_value=True)
+                mock_loop_instance.run_in_executor = AsyncMock(return_value=[True])
                 mock_loop.return_value = mock_loop_instance
 
                 result = await pusher.send_notification(urls, title, body)
@@ -124,6 +124,46 @@ class TestApprisePusher:
                 assert result["success"] is True
                 assert result["valid_urls"] == 1
                 assert result["invalid_urls"] == 1
+
+    @pytest.mark.asyncio
+    async def test_send_notification_partial_success(self):
+        """测试发送通知部分成功（2/3成功）"""
+        pusher = ApprisePusher()
+        urls = [
+            "bark://test_key1@api.day.app",
+            "bark://test_key2@api.day.app",
+            "dotpush://test_key3",
+        ]
+        title = "测试标题"
+        body = "测试内容"
+
+        with patch(
+            "jjz_alert.service.notification.apprise_pusher.apprise"
+        ) as mock_apprise:
+            mock_instance = Mock()
+            mock_instance.add.return_value = True
+            # 模拟2个成功，1个失败
+            mock_instance.async_notify.return_value = [True, True, False]
+            mock_apprise.Apprise.return_value = mock_instance
+
+            with patch("asyncio.get_event_loop") as mock_loop:
+                mock_loop_instance = Mock()
+                mock_loop_instance.run_in_executor = AsyncMock(
+                    return_value=[True, True, False]
+                )
+                mock_loop.return_value = mock_loop_instance
+
+                result = await pusher.send_notification(urls, title, body)
+
+                # 应该成功，因为至少有一个成功
+                assert result["success"] is True
+                assert result["valid_urls"] == 3
+                assert result["invalid_urls"] == 0
+                # 检查URL结果
+                assert len(result["url_results"]) == 3
+                assert result["url_results"][0]["success"] is True
+                assert result["url_results"][1]["success"] is True
+                assert result["url_results"][2]["success"] is False
 
     @pytest.mark.asyncio
     async def test_send_notification_failure(self):
@@ -138,12 +178,12 @@ class TestApprisePusher:
         ) as mock_apprise:
             mock_instance = Mock()
             mock_instance.add.return_value = True
-            mock_instance.notify.return_value = False
+            mock_instance.async_notify.return_value = [False]  # 返回失败列表
             mock_apprise.Apprise.return_value = mock_instance
 
             with patch("asyncio.get_event_loop") as mock_loop:
                 mock_loop_instance = Mock()
-                mock_loop_instance.run_in_executor = AsyncMock(return_value=False)
+                mock_loop_instance.run_in_executor = AsyncMock(return_value=[False])
                 mock_loop.return_value = mock_loop_instance
 
                 result = await pusher.send_notification(urls, title, body)

--- a/tests/unit/service/test_apprise_pusher.py
+++ b/tests/unit/service/test_apprise_pusher.py
@@ -285,6 +285,36 @@ class TestApprisePusher:
 
         assert masked == "****"
 
+    def test_mask_url_with_at_in_password(self):
+        """测试URL遮蔽 - 密码包含@符号"""
+        pusher = ApprisePusher()
+        # 模拟 SMTP URL，密码中包含 @ 符号
+        # 格式: smtp://username:p@ssword@smtp.example.com/
+        url = "smtp://user:p@ssw0rd@smtp.example.com/path"
+        masked = pusher._mask_url(url)
+
+        # 验证 scheme 保留
+        assert "smtp://" in masked
+        # 验证 host 正确识别（不应包含密码的一部分）
+        assert "smtp.example.com" in masked
+        # 验证 userinfo 被遮蔽
+        assert "****" in masked
+        # 验证密码中的 @ 不会导致错误的 host 识别
+        assert "ssw0rd@smtp.example.com" not in masked
+        # 验证整个 userinfo（user:p@ssw0rd）被遮蔽
+        assert "p@ssw0rd" not in masked
+
+    def test_mask_url_with_at_in_password_no_path(self):
+        """测试URL遮蔽 - 密码包含@符号且无路径"""
+        pusher = ApprisePusher()
+        url = "smtp://user:p@ssw0rd@smtp.example.com"
+        masked = pusher._mask_url(url)
+
+        assert "smtp://" in masked
+        assert "smtp.example.com" in masked
+        assert "****" in masked
+        assert "p@ssw0rd" not in masked
+
     def test_sanitize_error_message_with_url(self):
         """测试错误消息清理 - 包含URL"""
         pusher = ApprisePusher()

--- a/tests/unit/service/test_apprise_pusher.py
+++ b/tests/unit/service/test_apprise_pusher.py
@@ -66,7 +66,7 @@ class TestApprisePusher:
 
             mock_apprise.Apprise.side_effect = [validation_instance, single_instance]
 
-            with patch("asyncio.get_event_loop") as mock_loop:
+            with patch("asyncio.get_running_loop") as mock_loop:
                 mock_loop_instance = Mock()
                 mock_loop_instance.run_in_executor = AsyncMock(return_value=True)
                 mock_loop.return_value = mock_loop_instance
@@ -122,7 +122,7 @@ class TestApprisePusher:
 
             mock_apprise.Apprise.side_effect = [validation_instance, single_instance]
 
-            with patch("asyncio.get_event_loop") as mock_loop:
+            with patch("asyncio.get_running_loop") as mock_loop:
                 mock_loop_instance = Mock()
                 mock_loop_instance.run_in_executor = AsyncMock(return_value=True)
                 mock_loop.return_value = mock_loop_instance
@@ -166,7 +166,7 @@ class TestApprisePusher:
                 single_instances[2],
             ]
 
-            with patch("asyncio.get_event_loop") as mock_loop:
+            with patch("asyncio.get_running_loop") as mock_loop:
                 mock_loop_instance = Mock()
                 # 模拟3次run_in_executor调用，返回True, True, False
                 mock_loop_instance.run_in_executor = AsyncMock(
@@ -207,7 +207,7 @@ class TestApprisePusher:
 
             mock_apprise.Apprise.side_effect = [validation_instance, single_instance]
 
-            with patch("asyncio.get_event_loop") as mock_loop:
+            with patch("asyncio.get_running_loop") as mock_loop:
                 mock_loop_instance = Mock()
                 mock_loop_instance.run_in_executor = AsyncMock(
                     return_value=False

--- a/tests/unit/service/test_apprise_pusher.py
+++ b/tests/unit/service/test_apprise_pusher.py
@@ -49,7 +49,7 @@ class TestApprisePusher:
 
     @pytest.mark.asyncio
     async def test_send_notification_success(self):
-        """测试发送通知成功"""
+        """测试发送通知成功（全部成功）"""
         pusher = ApprisePusher()
         urls = ["bark://test_key@api.day.app"]
         title = "测试标题"
@@ -58,19 +58,23 @@ class TestApprisePusher:
         with patch(
             "jjz_alert.service.notification.apprise_pusher.apprise"
         ) as mock_apprise:
-            mock_instance = Mock()
-            mock_instance.add.return_value = True
-            mock_instance.async_notify.return_value = [True]  # 返回列表
-            mock_apprise.Apprise.return_value = mock_instance
+            # 验证实例和单独发送实例
+            validation_instance = Mock()
+            validation_instance.add.return_value = True
+            single_instance = Mock()
+            single_instance.add.return_value = True
+
+            mock_apprise.Apprise.side_effect = [validation_instance, single_instance]
 
             with patch("asyncio.get_event_loop") as mock_loop:
                 mock_loop_instance = Mock()
-                mock_loop_instance.run_in_executor = AsyncMock(return_value=[True])
+                mock_loop_instance.run_in_executor = AsyncMock(return_value=True)
                 mock_loop.return_value = mock_loop_instance
 
                 result = await pusher.send_notification(urls, title, body)
 
                 assert result["success"] is True
+                assert result["partial_success"] is False  # 全部成功，不是部分成功
                 assert result["title"] == title
                 assert result["body"] == body
                 assert result["valid_urls"] == 1
@@ -109,14 +113,18 @@ class TestApprisePusher:
         with patch(
             "jjz_alert.service.notification.apprise_pusher.apprise"
         ) as mock_apprise:
-            mock_instance = Mock()
-            mock_instance.add.side_effect = [True, False]
-            mock_instance.async_notify.return_value = [True]  # 只有一个有效URL
-            mock_apprise.Apprise.return_value = mock_instance
+            # 验证实例
+            validation_instance = Mock()
+            validation_instance.add.side_effect = [True, False]  # 第1个有效，第2个无效
+            # 只有1个有效URL，所以只需要1个单独发送实例
+            single_instance = Mock()
+            single_instance.add.return_value = True
+
+            mock_apprise.Apprise.side_effect = [validation_instance, single_instance]
 
             with patch("asyncio.get_event_loop") as mock_loop:
                 mock_loop_instance = Mock()
-                mock_loop_instance.run_in_executor = AsyncMock(return_value=[True])
+                mock_loop_instance.run_in_executor = AsyncMock(return_value=True)
                 mock_loop.return_value = mock_loop_instance
 
                 result = await pusher.send_notification(urls, title, body)
@@ -140,16 +148,29 @@ class TestApprisePusher:
         with patch(
             "jjz_alert.service.notification.apprise_pusher.apprise"
         ) as mock_apprise:
-            mock_instance = Mock()
-            mock_instance.add.return_value = True
-            # 模拟2个成功，1个失败
-            mock_instance.async_notify.return_value = [True, True, False]
-            mock_apprise.Apprise.return_value = mock_instance
+            # 第一个实例用于验证URLs
+            validation_instance = Mock()
+            validation_instance.add.return_value = True
+
+            # 为每个URL创建单独的实例
+            single_instances = [Mock(), Mock(), Mock()]
+            single_instances[0].add.return_value = True
+            single_instances[1].add.return_value = True
+            single_instances[2].add.return_value = True
+
+            # 模拟Apprise()被调用4次（1次验证 + 3次单独发送）
+            mock_apprise.Apprise.side_effect = [
+                validation_instance,
+                single_instances[0],
+                single_instances[1],
+                single_instances[2],
+            ]
 
             with patch("asyncio.get_event_loop") as mock_loop:
                 mock_loop_instance = Mock()
+                # 模拟3次run_in_executor调用，返回True, True, False
                 mock_loop_instance.run_in_executor = AsyncMock(
-                    return_value=[True, True, False]
+                    side_effect=[True, True, False]
                 )
                 mock_loop.return_value = mock_loop_instance
 
@@ -157,6 +178,8 @@ class TestApprisePusher:
 
                 # 应该成功，因为至少有一个成功
                 assert result["success"] is True
+                # 应该标记为部分成功（不是全部成功）
+                assert result["partial_success"] is True
                 assert result["valid_urls"] == 3
                 assert result["invalid_urls"] == 0
                 # 检查URL结果
@@ -176,14 +199,17 @@ class TestApprisePusher:
         with patch(
             "jjz_alert.service.notification.apprise_pusher.apprise"
         ) as mock_apprise:
-            mock_instance = Mock()
-            mock_instance.add.return_value = True
-            mock_instance.async_notify.return_value = [False]  # 返回失败列表
-            mock_apprise.Apprise.return_value = mock_instance
+            # 验证实例和单独发送实例
+            validation_instance = Mock()
+            validation_instance.add.return_value = True
+            single_instance = Mock()
+            single_instance.add.return_value = True
+
+            mock_apprise.Apprise.side_effect = [validation_instance, single_instance]
 
             with patch("asyncio.get_event_loop") as mock_loop:
                 mock_loop_instance = Mock()
-                mock_loop_instance.run_in_executor = AsyncMock(return_value=[False])
+                mock_loop_instance.run_in_executor = AsyncMock(return_value=False)  # 推送失败
                 mock_loop.return_value = mock_loop_instance
 
                 result = await pusher.send_notification(urls, title, body)


### PR DESCRIPTION
修复了Apprise推送成功率计算不准确的问题。

问题描述：
- 当多个推送通道部分成功时（例如2/3成功），系统错误地将所有通道标记为失败
- 日志显示"成功率0.0%"，实际应该是66.7%

根本原因：
- 使用Apprise的notify()方法，该方法返回全局布尔值（所有成功才为True）
- 将这个全局标志错误地应用到所有URL，导致部分失败被判定为全部失败

修复方案：
- 使用async_notify()方法获取每个URL的独立推送结果
- 逐个统计每个URL的成功/失败状态
- 改进日志信息："Apprise推送完成: M/N个通道成功"

测试：
- 更新所有单元测试以匹配新的async_notify() API
- 新增test_send_notification_partial_success测试用例验证部分成功场景
- 所有21个测试全部通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors Apprise notifications to send per-URL in parallel, report per-URL/partial success, and mask/sanitize sensitive data with updated tests.
> 
> - **Service (`jjz_alert/service/notification/apprise_pusher.py`)**
>   - Parallel per-URL sends using separate `Apprise()` instances and `asyncio.gather`, returning detailed `url_results`.
>   - Correct success calculation: overall `success` if any URL succeeds; adds `partial_success` flag and success counts in logs.
>   - Validates URLs (skip empty/non-str) and caches masked URLs for logging and results.
>   - Adds `_sanitize_error_message` and strengthens `_mask_url` (segment by `@` and `/`), plus token masking via precompiled regex.
>   - Enhances returned result with timing, counts, and timestamp; improves error handling and logging.
> - **Tests (`tests/unit/service/test_apprise_pusher.py`)**
>   - Update mocks to per-URL instances and `get_running_loop` executor usage.
>   - Add tests for partial success (e.g., 2/3), mixed/invalid URLs, and failure paths.
>   - Add/expand tests for URL masking (including `@` in password) and error-message sanitization.
>   - Maintain/extend validation and connection tests with new fields.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 26c565d5f69789e4597a309e7b7997e72d63c100. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->