### PR TITLE
revert: pin curl-cffi back to 0.13.0 for Python 3.14 compatibility

### DIFF
--- a/requirements-prod.txt
+++ b/requirements-prod.txt
@@ -1,4 +1,4 @@
-curl-cffi==0.14.0
+curl-cffi==0.13.0
 apscheduler==3.11.2
 PyYAML==6.0.3
 urllib3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-curl-cffi==0.14.0
+curl-cffi==0.13.0
 apscheduler==3.11.2
 PyYAML==6.0.3
 urllib3


### PR DESCRIPTION
## Summary
- curl-cffi 0.14.0 (merged via #38) does not publish prebuilt wheels for `cp314` (Python 3.14)
- Docker build fails at `pip download --only-binary=:all:` step
- Revert to 0.13.0 which has cp314 wheels available

## Test plan
- [x] Docker build should pass with 0.13.0
- [x] No code changes, only version pin

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency pin change only. Main impact is potential behavior differences/regressions between `curl-cffi` 0.14.0 and 0.13.0, but no application code is modified.
> 
> **Overview**
> Reverts the `curl-cffi` dependency pin from `0.14.0` back to `0.13.0` in both `requirements.txt` and `requirements-prod.txt` to restore compatibility with Python 3.14 (wheel availability) and unblock builds.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7c82ec52a421802cd77e9cad1fc88c435f86b914. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->