### PR TITLE
fix: 区分"审核通过(待生效)"和"审核中"状态的推送显示

### DIFF
--- a/jjz_alert/base/message_templates.py
+++ b/jjz_alert/base/message_templates.py
@@ -40,6 +40,11 @@ class MessageTemplateManager:
                 "车牌${display_name}的进京证(${jjz_type})状态：审核中，"
                 "申请时间 ${apply_time}。请关注审核进度。"
             ),
+            # 审核通过(待生效)状态模板
+            "approved_pending_status": (
+                "车牌${display_name}的进京证(${jjz_type})状态：审核通过(待生效)，"
+                "有效期 ${valid_start} 至 ${valid_end}。将在生效日期自动生效，无需操作。"
+            ),
             # 错误状态模板
             "error_status": (
                 "车牌${display_name}的进京证(${jjz_type})状态：${status}。${error_msg}"
@@ -170,6 +175,33 @@ class MessageTemplateManager:
             # 返回备用格式
             return f"车牌{display_name}的进京证({jjz_type})状态：审核中，申请时间 {apply_time}。请关注审核进度。"
 
+    def format_approved_pending_status(
+        self, display_name: str, jjz_type: str, valid_start: str, valid_end: str
+    ) -> str:
+        """
+        格式化审核通过(待生效)状态消息
+
+        Args:
+            display_name: 显示名称
+            jjz_type: 进京证类型
+            valid_start: 有效期开始
+            valid_end: 有效期结束
+
+        Returns:
+            格式化的消息内容
+        """
+        try:
+            template = Template(self.templates["approved_pending_status"])
+            return template.safe_substitute(
+                display_name=display_name,
+                jjz_type=jjz_type,
+                valid_start=valid_start,
+                valid_end=valid_end,
+            )
+        except Exception as e:
+            self.logger.error(f"格式化审核通过(待生效)状态消息失败: {e}")
+            return f"车牌{display_name}的进京证({jjz_type})状态：审核通过(待生效)，有效期 {valid_start} 至 {valid_end}。"
+
     def format_error_status(
         self, display_name: str, jjz_type: str, status: str, error_msg: str
     ) -> str:
@@ -295,6 +327,7 @@ def initialize_templates_from_config(config_manager=None):
             "valid_status",
             "expired_status",
             "pending_status",
+            "approved_pending_status",
             "error_status",
             "traffic_reminder_prefix",
             "sycs_part",

--- a/jjz_alert/config/config.py
+++ b/jjz_alert/config/config.py
@@ -222,6 +222,9 @@ class ConfigManager:
                     valid_status=template_data.get("valid_status"),
                     expired_status=template_data.get("expired_status"),
                     pending_status=template_data.get("pending_status"),
+                    approved_pending_status=template_data.get(
+                        "approved_pending_status"
+                    ),
                     error_status=template_data.get("error_status"),
                     traffic_reminder_prefix=template_data.get(
                         "traffic_reminder_prefix"

--- a/jjz_alert/config/config_models.py
+++ b/jjz_alert/config/config_models.py
@@ -97,6 +97,7 @@ class MessageTemplateConfig:
     valid_status: Optional[str] = None
     expired_status: Optional[str] = None
     pending_status: Optional[str] = None
+    approved_pending_status: Optional[str] = None
     error_status: Optional[str] = None
     traffic_reminder_prefix: Optional[str] = None
     sycs_part: Optional[str] = None

--- a/jjz_alert/service/jjz/jjz_service.py
+++ b/jjz_alert/service/jjz/jjz_service.py
@@ -141,11 +141,11 @@ class JJZService:
                                 JJZStatusEnum.VALID.value
                             )  # 待生效但在有效期内，视为有效
                         else:
-                            return JJZStatusEnum.PENDING.value  # 待生效但还未到生效时间
+                            return JJZStatusEnum.APPROVED_PENDING.value  # 待生效但还未到生效时间
                     except Exception:
-                        return JJZStatusEnum.PENDING.value
+                        return JJZStatusEnum.APPROVED_PENDING.value
                 else:
-                    return JJZStatusEnum.PENDING.value
+                    return JJZStatusEnum.APPROVED_PENDING.value
             elif (blzt == "0" or blzt == 0) or "审核中" in blztmc:
                 return JJZStatusEnum.PENDING.value
             else:

--- a/jjz_alert/service/jjz/jjz_service.py
+++ b/jjz_alert/service/jjz/jjz_service.py
@@ -141,7 +141,9 @@ class JJZService:
                                 JJZStatusEnum.VALID.value
                             )  # 待生效但在有效期内，视为有效
                         else:
-                            return JJZStatusEnum.APPROVED_PENDING.value  # 待生效但还未到生效时间
+                            return (
+                                JJZStatusEnum.APPROVED_PENDING.value
+                            )  # 待生效但还未到生效时间
                     except Exception:
                         return JJZStatusEnum.APPROVED_PENDING.value
                 else:

--- a/jjz_alert/service/jjz/jjz_status_enum.py
+++ b/jjz_alert/service/jjz/jjz_status_enum.py
@@ -11,6 +11,7 @@ class JJZStatusEnum(str, Enum):
     VALID = "valid"
     EXPIRED = "expired"
     PENDING = "pending"
+    APPROVED_PENDING = "approved_pending"
     INVALID = "invalid"
     ERROR = "error"
     UNKNOWN = "unknown"
@@ -56,6 +57,10 @@ class JJZStatusEnum(str, Enum):
         return self == self.PENDING
 
     @property
+    def is_approved_pending(self) -> bool:
+        return self == self.APPROVED_PENDING
+
+    @property
     def is_invalid(self) -> bool:
         return self == self.INVALID
 
@@ -65,7 +70,7 @@ class JJZStatusEnum(str, Enum):
 
     @property
     def is_actionable(self) -> bool:
-        return self in (self.VALID, self.EXPIRED)
+        return self in (self.VALID, self.EXPIRED, self.APPROVED_PENDING)
 
     @property
     def needs_attention(self) -> bool:
@@ -77,6 +82,7 @@ class JJZStatusEnum(str, Enum):
             self.VALID: "有效",
             self.EXPIRED: "已过期",
             self.PENDING: "审核中",
+            self.APPROVED_PENDING: "审核通过(待生效)",
             self.INVALID: "无效",
             self.ERROR: "错误",
             self.UNKNOWN: "未知",

--- a/jjz_alert/service/jjz/jjz_utils.py
+++ b/jjz_alert/service/jjz/jjz_utils.py
@@ -173,6 +173,31 @@ def format_jjz_pending_content(display_name: str, jjzzlmc: str, apply_time: str)
     return template_manager.format_pending_status(display_name, jjz_type, apply_time)
 
 
+def format_jjz_approved_pending_content(
+    display_name: str, jjzzlmc: str, valid_start: str, valid_end: str
+) -> str:
+    """
+    格式化进京证审核通过(待生效)推送内容
+
+    Args:
+        display_name: 显示名称
+        jjzzlmc: 进京证类型名称
+        valid_start: 有效期开始
+        valid_end: 有效期结束
+
+    Returns:
+        格式化的推送内容
+    """
+    from jjz_alert.base.message_templates import template_manager
+
+    jjz_type = extract_jjz_type_from_jjzzlmc(jjzzlmc)
+    disp_start, disp_end = format_valid_dates(valid_start, valid_end)
+
+    return template_manager.format_approved_pending_status(
+        display_name, jjz_type, disp_start, disp_end
+    )
+
+
 def format_jjz_error_content(
     display_name: str, jjzzlmc: str, status: str, error_msg: str
 ) -> str:
@@ -239,6 +264,14 @@ def format_jjz_body_and_priority(
             display_name=display_name,
             jjzzlmc=jjz_data.get("jjzzlmc", ""),
             apply_time=jjz_data.get("apply_time", "未知"),
+        )
+    elif status == JJZStatusEnum.APPROVED_PENDING.value:
+        priority = "normal"
+        body = format_jjz_approved_pending_content(
+            display_name=display_name,
+            jjzzlmc=jjz_data.get("jjzzlmc", ""),
+            valid_start=jjz_data.get("valid_start", "未知"),
+            valid_end=jjz_data.get("valid_end", "未知"),
         )
     else:
         priority = "normal"

--- a/jjz_alert/service/notification/push_helpers.py
+++ b/jjz_alert/service/notification/push_helpers.py
@@ -51,6 +51,7 @@ async def push_jjz_status(
             format_jjz_push_content,
             format_jjz_expired_content,
             format_jjz_pending_content,
+            format_jjz_approved_pending_content,
             format_jjz_error_content,
         )
 
@@ -92,6 +93,18 @@ async def push_jjz_status(
                 display_name=display_name,
                 jjzzlmc=jjz_data.get("jjzzlmc", ""),
                 apply_time=apply_time,
+            )
+
+        elif status == JJZStatusEnum.APPROVED_PENDING.value:
+            priority = PushPriority.NORMAL
+            logging.debug(
+                f"[STATUS_DEBUG] 车牌 {plate} - 状态为APPROVED_PENDING，设置优先级为NORMAL"
+            )
+            body = format_jjz_approved_pending_content(
+                display_name=display_name,
+                jjzzlmc=jjz_data.get("jjzzlmc", ""),
+                valid_start=jjz_data.get("valid_start", "未知"),
+                valid_end=jjz_data.get("valid_end", "未知"),
             )
 
         else:

--- a/tests/unit/core/test_message_templates.py
+++ b/tests/unit/core/test_message_templates.py
@@ -167,6 +167,38 @@ class TestMessageTemplateManager:
             assert "京I77777" in result
             assert "审核中" in result
 
+    def test_format_approved_pending_status(self):
+        """测试格式化审核通过(待生效)状态"""
+        manager = mt.MessageTemplateManager()
+
+        result = manager.format_approved_pending_status(
+            display_name="京H66666",
+            jjz_type="六环外",
+            valid_start="04-05",
+            valid_end="04-11",
+        )
+
+        assert "京H66666" in result
+        assert "审核通过(待生效)" in result
+        assert "04-05" in result
+        assert "04-11" in result
+
+    def test_format_approved_pending_status_exception_handling(self):
+        """测试格式化审核通过(待生效)状态时的异常处理"""
+        manager = mt.MessageTemplateManager()
+        with patch("jjz_alert.base.message_templates.Template") as mock_template:
+            mock_template.side_effect = Exception("模板错误")
+
+            result = manager.format_approved_pending_status(
+                display_name="京I77777",
+                jjz_type="六环外",
+                valid_start="04-05",
+                valid_end="04-11",
+            )
+
+            assert "京I77777" in result
+            assert "审核通过(待生效)" in result
+
     def test_format_error_status(self):
         """测试格式化错误状态"""
         manager = mt.MessageTemplateManager()

--- a/tests/unit/service/test_jjz_service.py
+++ b/tests/unit/service/test_jjz_service.py
@@ -48,7 +48,7 @@ class TestJJZService:
             status = jjz_service._determine_status(
                 "6", "审核通过(待生效)", "2025-08-20", "2025-08-15"
             )
-            assert status == JJZStatusEnum.PENDING.value
+            assert status == JJZStatusEnum.APPROVED_PENDING.value
 
     def test_determine_status_expired(self, jjz_service):
         """测试新版状态判断 - 已过期"""
@@ -165,7 +165,7 @@ class TestJJZService:
 
         assert len(records) == 2
         assert records[0].status == JJZStatusEnum.VALID.value
-        assert records[1].status == JJZStatusEnum.PENDING.value
+        assert records[1].status == JJZStatusEnum.APPROVED_PENDING.value
 
     @pytest.mark.asyncio
     async def test_get_jjz_status_always_fetch_from_api(
@@ -655,7 +655,7 @@ class TestJJZService:
             status = jjz_service._determine_status(
                 "6", "审核通过(待生效)", "2025-08-20", "2025-08-15"
             )
-            assert status == JJZStatusEnum.PENDING.value
+            assert status == JJZStatusEnum.APPROVED_PENDING.value
 
     def test_determine_status_pending_no_yxqs(self, jjz_service):
         """测试状态判断 - 待生效但无开始日期"""
@@ -664,7 +664,7 @@ class TestJJZService:
             status = jjz_service._determine_status(
                 "6", "审核通过(待生效)", "2025-08-20", None
             )
-            assert status == JJZStatusEnum.PENDING.value
+            assert status == JJZStatusEnum.APPROVED_PENDING.value
 
     def test_determine_status_auditing(self, jjz_service):
         """测试状态判断 - 审核中"""
@@ -690,7 +690,7 @@ class TestJJZService:
             status = jjz_service._determine_status(
                 "6", "审核通过(待生效)", "2025-08-20", "invalid-date"
             )
-            assert status == JJZStatusEnum.PENDING.value
+            assert status == JJZStatusEnum.APPROVED_PENDING.value
 
     def test_determine_status_unknown_blzt(self, jjz_service):
         """测试状态判断 - 未知的blzt值"""

--- a/tests/unit/service/test_jjz_status_enum.py
+++ b/tests/unit/service/test_jjz_status_enum.py
@@ -16,6 +16,7 @@ class TestJJZStatusEnum:
         assert str(JJZStatusEnum.VALID) == "valid"
         assert str(JJZStatusEnum.EXPIRED) == "expired"
         assert str(JJZStatusEnum.PENDING) == "pending"
+        assert str(JJZStatusEnum.APPROVED_PENDING) == "approved_pending"
         assert str(JJZStatusEnum.INVALID) == "invalid"
         assert str(JJZStatusEnum.ERROR) == "error"
         assert str(JJZStatusEnum.UNKNOWN) == "unknown"
@@ -32,6 +33,7 @@ class TestJJZStatusEnum:
         assert JJZStatusEnum.from_string("  valid  ") == JJZStatusEnum.VALID
         assert JJZStatusEnum.from_string("expired") == JJZStatusEnum.EXPIRED
         assert JJZStatusEnum.from_string("pending") == JJZStatusEnum.PENDING
+        assert JJZStatusEnum.from_string("approved_pending") == JJZStatusEnum.APPROVED_PENDING
         assert JJZStatusEnum.from_string("invalid") == JJZStatusEnum.INVALID
         assert JJZStatusEnum.from_string("error") == JJZStatusEnum.ERROR
         assert JJZStatusEnum.from_string("unknown") == JJZStatusEnum.UNKNOWN
@@ -92,11 +94,18 @@ class TestJJZStatusEnum:
     def test_is_pending_property(self):
         """测试 is_pending 属性"""
         assert JJZStatusEnum.PENDING.is_pending is True
+        assert JJZStatusEnum.APPROVED_PENDING.is_pending is False
         assert JJZStatusEnum.VALID.is_pending is False
         assert JJZStatusEnum.EXPIRED.is_pending is False
         assert JJZStatusEnum.INVALID.is_pending is False
         assert JJZStatusEnum.ERROR.is_pending is False
         assert JJZStatusEnum.UNKNOWN.is_pending is False
+
+    def test_is_approved_pending_property(self):
+        """测试 is_approved_pending 属性"""
+        assert JJZStatusEnum.APPROVED_PENDING.is_approved_pending is True
+        assert JJZStatusEnum.PENDING.is_approved_pending is False
+        assert JJZStatusEnum.VALID.is_approved_pending is False
 
     def test_is_invalid_property(self):
         """测试 is_invalid 属性"""
@@ -120,6 +129,7 @@ class TestJJZStatusEnum:
         """测试 is_actionable 属性"""
         assert JJZStatusEnum.VALID.is_actionable is True
         assert JJZStatusEnum.EXPIRED.is_actionable is True
+        assert JJZStatusEnum.APPROVED_PENDING.is_actionable is True
         assert JJZStatusEnum.PENDING.is_actionable is False
         assert JJZStatusEnum.INVALID.is_actionable is False
         assert JJZStatusEnum.ERROR.is_actionable is False
@@ -132,6 +142,7 @@ class TestJJZStatusEnum:
         assert JJZStatusEnum.INVALID.needs_attention is True
         assert JJZStatusEnum.VALID.needs_attention is False
         assert JJZStatusEnum.PENDING.needs_attention is False
+        assert JJZStatusEnum.APPROVED_PENDING.needs_attention is False
         assert JJZStatusEnum.UNKNOWN.needs_attention is False
 
     def test_description_property(self):
@@ -139,6 +150,7 @@ class TestJJZStatusEnum:
         assert JJZStatusEnum.VALID.description == "有效"
         assert JJZStatusEnum.EXPIRED.description == "已过期"
         assert JJZStatusEnum.PENDING.description == "审核中"
+        assert JJZStatusEnum.APPROVED_PENDING.description == "审核通过(待生效)"
         assert JJZStatusEnum.INVALID.description == "无效"
         assert JJZStatusEnum.ERROR.description == "错误"
         assert JJZStatusEnum.UNKNOWN.description == "未知"

--- a/tests/unit/service/test_jjz_status_enum.py
+++ b/tests/unit/service/test_jjz_status_enum.py
@@ -33,7 +33,10 @@ class TestJJZStatusEnum:
         assert JJZStatusEnum.from_string("  valid  ") == JJZStatusEnum.VALID
         assert JJZStatusEnum.from_string("expired") == JJZStatusEnum.EXPIRED
         assert JJZStatusEnum.from_string("pending") == JJZStatusEnum.PENDING
-        assert JJZStatusEnum.from_string("approved_pending") == JJZStatusEnum.APPROVED_PENDING
+        assert (
+            JJZStatusEnum.from_string("approved_pending")
+            == JJZStatusEnum.APPROVED_PENDING
+        )
         assert JJZStatusEnum.from_string("invalid") == JJZStatusEnum.INVALID
         assert JJZStatusEnum.from_string("error") == JJZStatusEnum.ERROR
         assert JJZStatusEnum.from_string("unknown") == JJZStatusEnum.UNKNOWN

--- a/tests/unit/service/test_jjz_utils.py
+++ b/tests/unit/service/test_jjz_utils.py
@@ -318,6 +318,26 @@ class TestFormatJJZBodyAndPriority:
         mock_template_manager.format_pending_status.assert_called_once()
 
     @patch("jjz_alert.base.message_templates.template_manager")
+    def test_format_approved_pending_status(self, mock_template_manager):
+        """测试审核通过(待生效)状态格式化"""
+        mock_template_manager.format_approved_pending_status.return_value = (
+            "审核通过待生效内容"
+        )
+
+        jjz_data = {
+            "status": "approved_pending",
+            "jjzzlmc": "进京证（六环外）",
+            "valid_start": "2026-04-05",
+            "valid_end": "2026-04-11",
+        }
+
+        body, priority = jjz_utils.format_jjz_body_and_priority("京A12345", jjz_data)
+
+        assert body == "审核通过待生效内容"
+        assert priority == "normal"
+        mock_template_manager.format_approved_pending_status.assert_called_once()
+
+    @patch("jjz_alert.base.message_templates.template_manager")
     def test_format_error_status(self, mock_template_manager):
         """测试错误状态格式化"""
         mock_template_manager.format_error_status.return_value = "错误内容"

--- a/tests/unit/service/test_push_helpers.py
+++ b/tests/unit/service/test_push_helpers.py
@@ -116,6 +116,32 @@ class TestPushJJZStatus:
             assert call_args.kwargs["priority"] == PushPriority.HIGH
 
     @pytest.mark.asyncio
+    async def test_push_jjz_status_approved_pending(self, plate_config):
+        """测试推送进京证状态 - 审核通过(待生效)状态"""
+        jjz_data = {
+            "status": JJZStatusEnum.APPROVED_PENDING.value,
+            "jjzzlmc": "进京证（六环外）",
+            "valid_start": "2026-04-05",
+            "valid_end": "2026-04-11",
+        }
+
+        with patch(
+            "jjz_alert.service.notification.push_helpers.unified_pusher.push"
+        ) as mock_push:
+            mock_push.return_value = {
+                "plate": "京A12345",
+                "success_count": 1,
+                "total_count": 1,
+            }
+
+            result = await push_jjz_status(plate_config, jjz_data)
+
+            assert result["success_count"] == 1
+            mock_push.assert_called_once()
+            call_args = mock_push.call_args
+            assert call_args.kwargs["priority"] == PushPriority.NORMAL
+
+    @pytest.mark.asyncio
     async def test_push_jjz_status_system_error(self, plate_config):
         """测试推送进京证状态 - 系统级错误"""
         jjz_data = {

--- a/tests/unit/test_jjz_service.py
+++ b/tests/unit/test_jjz_service.py
@@ -48,7 +48,7 @@ class TestJJZService:
             status = jjz_service._determine_status(
                 "6", "审核通过(待生效)", "2025-08-20", "2025-08-15"
             )
-            assert status == JJZStatusEnum.PENDING.value
+            assert status == JJZStatusEnum.APPROVED_PENDING.value
 
     def test_determine_status_expired(self, jjz_service):
         """测试新版状态判断 - 已过期"""
@@ -165,7 +165,7 @@ class TestJJZService:
 
         assert len(records) == 2
         assert records[0].status == JJZStatusEnum.VALID.value
-        assert records[1].status == JJZStatusEnum.PENDING.value
+        assert records[1].status == JJZStatusEnum.APPROVED_PENDING.value
 
     @pytest.mark.asyncio
     async def test_get_jjz_status_always_fetch_from_api(


### PR DESCRIPTION
blzt=6 的进京证（审核通过待生效）之前被映射为 PENDING 状态，
导致推送通知错误显示为"审核中"。新增 APPROVED_PENDING 枚举值，
使用独立的通知模板正确显示"审核通过(待生效)"，并将优先级设为 NORMAL。

https://claude.ai/code/session_0167JHetk5LieQ4XtZGYoskC

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new status enum and message template path, mainly affecting how status is classified and displayed in notifications; behavior is covered by updated unit tests.
> 
> **Overview**
> Fixes mislabeling of `blzt=6` (审核通过*待生效*) permits by introducing a new `APPROVED_PENDING` status instead of reusing `PENDING`, so pushes no longer show “审核中” for approved-but-not-yet-effective permits.
> 
> Adds a dedicated `approved_pending_status` message template (configurable via `message_templates`) plus new formatting helpers, and updates push logic to send this state with *NORMAL* priority while keeping “审核中” as *HIGH* priority. Unit tests are updated/added across status determination, templating, and push helpers to cover the new state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0a06f37678cf57530c1196b185227b79186bb23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->