### PR TITLE
chore: 升级 apprise 至 1.10.0

### DIFF
--- a/requirements-prod.txt
+++ b/requirements-prod.txt
@@ -9,7 +9,7 @@ pydantic
 redis>=5.0.0
 aioredis>=2.0.0
 # Apprise多通道推送
-apprise>=1.9.6
+apprise>=1.10.0
 # Home Assistant集成
 aiohttp>=3.8.0
 # MQTT（用于HA Discovery）

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ pydantic
 redis>=5.0.0
 aioredis>=2.0.0
 # Apprise多通道推送
-apprise>=1.9.6
+apprise>=1.10.0
 # Home Assistant集成
 aiohttp>=3.8.0 
 # MQTT（用于HA Discovery）


### PR DESCRIPTION
## Summary
- 将 apprise 依赖从 `>=1.9.6` 升级到 `>=1.10.0`，跟进上游 [v1.10.0 release](https://github.com/caronc/apprise/releases/tag/v1.10.0)
- 已核对 v1.10.0 的两个潜在 breaking change（`ntfy://` 的 `tags=`→`xtags=`、`Dot.` 插件 API v1→v2），项目均未使用对应 schema，无需代码改动
- `apprise.Apprise()` / `add()` / `notify()` 调用 API 未变，`apprise_pusher.py` 无影响

## Test plan
- [x] 临时 venv 安装 `apprise==1.10.0` 后跑 `tests/unit/service/test_apprise_pusher.py` / `test_push_helpers.py` / `test_batch_pusher.py` / `test_unified_pusher.py` 共 183 个用例全部通过
- [x] 跑 `tests/unit/test_validation.py` / `tests/unit/config/test_config.py` 共 74 个用例全部通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only change bumping the minimum `apprise` version; low risk but could surface upstream breaking changes at runtime if any integrations rely on altered schemas.
> 
> **Overview**
> Updates the `apprise` dependency constraint from `>=1.9.6` to `>=1.10.0` in both `requirements.txt` and `requirements-prod.txt`, aligning all environments on the newer Apprise release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04e87d95459454e6662b9b312d745c57510dd9f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->