### PR TITLE
feat: 自动续办改为事件驱动，由 remind 触发并按需派发

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+# Claude Code IDE 本地状态（plugin 缓存、loop lock、本地命令覆盖等，机器特定）
+.claude/
+
 # C extensions
 *.so
 

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -64,10 +64,10 @@ global:
     # 限行规则默认缓存到当天24:00
 
   # 自动续办全局配置（可选）
-  # 控制自动续办的随机执行时间窗口，避免固定时间请求
+  # 续办触发由 remind cron 驱动；以下控制每条续办协程派发后的拟人化随机延迟（秒）
   auto_renew:
-    time_window_start: "00:00"  # 随机窗口起始时间
-    time_window_end: "06:00"    # 随机窗口结束时间
+    min_delay_seconds: 30   # 派发后最小延迟，默认 30
+    max_delay_seconds: 180  # 派发后最大延迟，默认 180
 
   # Home Assistant集成配置（可选）
   homeassistant:

--- a/jjz_alert/config/config.py
+++ b/jjz_alert/config/config.py
@@ -238,9 +238,26 @@ class ConfigManager:
             # 自动续办全局配置
             if "auto_renew" in global_data:
                 ar_data = global_data["auto_renew"]
+                if "time_window_start" in ar_data or "time_window_end" in ar_data:
+                    logging.warning(
+                        "global.auto_renew.time_window_start / time_window_end 已废弃，"
+                        "将被忽略；请改用 min_delay_seconds / max_delay_seconds"
+                    )
+
+                def _coerce_delay(key: str, default: int) -> int:
+                    raw = ar_data.get(key, default)
+                    try:
+                        return int(raw)
+                    except (TypeError, ValueError):
+                        logging.warning(
+                            f"global.auto_renew.{key} 无法解析为整数 (got {raw!r})，"
+                            f"已退回默认值 {default}；如需自定义请在配置中给出非负整数"
+                        )
+                        return default
+
                 config.global_config.auto_renew = GlobalAutoRenewConfig(
-                    time_window_start=ar_data.get("time_window_start", "00:00"),
-                    time_window_end=ar_data.get("time_window_end", "06:00"),
+                    min_delay_seconds=_coerce_delay("min_delay_seconds", 30),
+                    max_delay_seconds=_coerce_delay("max_delay_seconds", 180),
                 )
 
             # 管理员配置

--- a/jjz_alert/config/config_models.py
+++ b/jjz_alert/config/config_models.py
@@ -110,8 +110,8 @@ class MessageTemplateConfig:
 class GlobalAutoRenewConfig:
     """全局自动续办配置"""
 
-    time_window_start: str = "00:00"
-    time_window_end: str = "06:00"
+    min_delay_seconds: int = 30
+    max_delay_seconds: int = 180
 
 
 @dataclass

--- a/jjz_alert/config/validation.py
+++ b/jjz_alert/config/validation.py
@@ -83,7 +83,7 @@ class ConfigValidator:
         # 验证自动续办全局配置
         ar_global = config.global_config.auto_renew
         if ar_global:
-            self._validate_auto_renew_time_window(ar_global)
+            self._validate_auto_renew_delay(ar_global)
 
         # 验证Home Assistant配置
         ha_config = config.global_config.homeassistant
@@ -246,25 +246,26 @@ class ConfigValidator:
                         f"{context}自动续办住宿配置缺少必需字段: {field_name}"
                     )
 
-    def _validate_auto_renew_time_window(self, ar_global):
-        """验证自动续办全局时间窗口配置"""
-        start = ar_global.time_window_start
-        end = ar_global.time_window_end
+    def _validate_auto_renew_delay(self, ar_global):
+        """验证自动续办全局派发延迟配置"""
+        min_delay = ar_global.min_delay_seconds
+        max_delay = ar_global.max_delay_seconds
 
-        if not self._validate_time_format(start):
-            self.errors.append(f"自动续办时间窗口起始时间格式无效: {start}")
+        if not isinstance(min_delay, int) or min_delay < 0:
+            self.errors.append(
+                f"续办延迟最小值必须为非负整数: min_delay_seconds={min_delay}"
+            )
             return
-        if not self._validate_time_format(end):
-            self.errors.append(f"自动续办时间窗口结束时间格式无效: {end}")
+        if not isinstance(max_delay, int) or max_delay < 0:
+            self.errors.append(
+                f"续办延迟最大值必须为非负整数: max_delay_seconds={max_delay}"
+            )
             return
-
-        # 起始时间必须早于结束时间
-        start_parts = list(map(int, start.split(":")))
-        end_parts = list(map(int, end.split(":")))
-        start_minutes = start_parts[0] * 60 + start_parts[1]
-        end_minutes = end_parts[0] * 60 + end_parts[1]
-        if start_minutes >= end_minutes:
-            self.errors.append("续办时间窗口起始时间必须早于结束时间")
+        if min_delay > max_delay:
+            self.errors.append(
+                "续办延迟最小值必须 >= 0 且不大于最大值: "
+                f"min_delay_seconds={min_delay}, max_delay_seconds={max_delay}"
+            )
 
     def _validate_admin_notifications(self, notifications: List[NotificationConfig]):
         """验证管理员推送配置"""

--- a/jjz_alert/service/jjz/auto_renew_service.py
+++ b/jjz_alert/service/jjz/auto_renew_service.py
@@ -1,26 +1,21 @@
 """
 六环外进京证自动续办服务
 
-在到期前一天自动提交续办申请，支持随机时间调度和结果通知。
+封装续办 API 调用链、请求体组装、结果通知和当日防重。
+触发由 `renew_trigger.schedule_renew` 派发，决策由 `renew_decider.decide` 给出。
 """
 
-import asyncio
 import logging
-import random
 import time
 from dataclasses import dataclass
-from datetime import datetime, date, timedelta
-from typing import Any, Dict, List, Optional
+from datetime import date
+from typing import Any, Dict, Optional
 
 from jjz_alert.base.http import http_post
 from jjz_alert.base.logger import get_structured_logger, LogCategory
 from jjz_alert.config.config_models import AutoRenewConfig, PlateConfig
-from jjz_alert.service.jjz.jjz_parse import (
-    extract_renew_metadata,
-    parse_all_jjz_records,
-)
+from jjz_alert.service.jjz.jjz_parse import extract_renew_metadata
 from jjz_alert.service.jjz.jjz_status import JJZStatus
-from jjz_alert.service.jjz.jjz_status_enum import JJZStatusEnum
 
 logger = logging.getLogger(__name__)
 
@@ -209,45 +204,6 @@ class AutoRenewService:
                 message=f"续办异常: {e}",
                 step="exception",
             )
-
-    # ------------------------------------------------------------------
-    # 续办判断
-    # ------------------------------------------------------------------
-
-    def should_renew(self, plate_config: PlateConfig, jjz_status: JJZStatus) -> bool:
-        """判断是否应触发续办"""
-        ar = plate_config.auto_renew
-        if not ar or not ar.enabled:
-            return False
-
-        # 仅六环外（jjzzlmc 为 None 或空时也不续办）
-        if not jjz_status.jjzzlmc or "六环外" not in jjz_status.jjzzlmc:
-            return False
-
-        # 已有待审记录
-        if jjz_status.sfyecbzxx:
-            logger.info(f"车牌 {plate_config.plate} 已有待审记录，跳过续办")
-            return False
-
-        # 注意：elzsfkb 的检查由调用方处理，以便在不可办理时推送通知
-
-        # 判断有效期：明天到期或已过期
-        if jjz_status.valid_end:
-            try:
-                end_date = datetime.strptime(jjz_status.valid_end, "%Y-%m-%d").date()
-                today = date.today()
-                tomorrow = today + timedelta(days=1)
-
-                if end_date <= tomorrow:
-                    return True
-            except (ValueError, TypeError):
-                pass
-
-        # 状态为过期
-        if jjz_status.status == JJZStatusEnum.EXPIRED.value:
-            return True
-
-        return False
 
     # ------------------------------------------------------------------
     # API 调用链
@@ -508,164 +464,5 @@ class AutoRenewService:
             except Exception as e:
                 logger.error(f"续办结果推送失败: {e}")
 
-    # ------------------------------------------------------------------
-    # 随机延迟
-    # ------------------------------------------------------------------
-
-    @staticmethod
-    def calculate_random_delay(
-        time_window_start: str = "00:00", time_window_end: str = "06:00"
-    ) -> int:
-        """计算从当前时刻到时间窗口内随机时刻的等待秒数"""
-        start_parts = list(map(int, time_window_start.split(":")))
-        end_parts = list(map(int, time_window_end.split(":")))
-        start_seconds = start_parts[0] * 3600 + start_parts[1] * 60
-        end_seconds = end_parts[0] * 3600 + end_parts[1] * 60
-
-        if start_seconds >= end_seconds:
-            logger.warning("续办时间窗口配置无效(start >= end)，跳过")
-            return -1
-
-        now = datetime.now()
-        now_seconds = now.hour * 3600 + now.minute * 60 + now.second
-
-        if now_seconds >= end_seconds:
-            # 已超过窗口结束时间，返回 -1 表示不应执行
-            return -1
-
-        # 有效随机范围的起点：窗口起始或当前时间（取较晚者）
-        effective_start = max(start_seconds, now_seconds)
-
-        # 从当前时刻到随机目标时刻的延迟
-        random_target = random.randint(effective_start, end_seconds - 1)
-        return random_target - now_seconds
-
-
 # 全局实例
 auto_renew_service = AutoRenewService()
-
-
-async def run_auto_renew_check():
-    """
-    自动续办检查入口 — 由定时任务调用
-
-    流程：随机延迟 → 加载配置 → 遍历启用续办的车牌 → 查询状态 → 执行续办 → 推送结果
-    """
-    from jjz_alert.config.config import config_manager
-    from jjz_alert.service.jjz.jjz_service import JJZService
-
-    app_config = config_manager.load_config()
-    ar_global = app_config.global_config.auto_renew
-
-    # 找出启用了续办的车牌
-    renew_plates = [
-        p for p in app_config.plates if p.auto_renew and p.auto_renew.enabled
-    ]
-    if not renew_plates:
-        logger.debug("无启用自动续办的车牌，跳过")
-        return
-
-    # 随机延迟
-    delay = AutoRenewService.calculate_random_delay(
-        ar_global.time_window_start, ar_global.time_window_end
-    )
-    if delay < 0:
-        logger.info(f"当前时间已超过续办窗口 {ar_global.time_window_end}，跳过本次执行")
-        return
-    if delay > 0:
-        target_time = datetime.now() + timedelta(seconds=delay)
-        logger.info(
-            f"自动续办将在 {target_time.strftime('%H:%M:%S')} 执行 "
-            f"(延迟 {delay // 60} 分钟)"
-        )
-        await asyncio.sleep(delay)
-
-    # 延迟后重新加载配置，确保使用最新的车牌和续办设置
-    app_config = config_manager.reload_config()
-    renew_plates = [
-        p for p in app_config.plates if p.auto_renew and p.auto_renew.enabled
-    ]
-    if not renew_plates:
-        logger.debug("延迟后重新检查：无启用自动续办的车牌，跳过")
-        return
-
-    logger.info(f"开始自动续办检查，共 {len(renew_plates)} 个车牌")
-
-    jjz_service = JJZService()
-
-    # 一次性查询所有车辆状态（stateList 返回所有车辆数据）
-    accounts = jjz_service.load_accounts()
-    if not accounts:
-        logger.error("无可用进京证账户")
-        return
-
-    response_data = jjz_service.check_jjz_status(
-        accounts[0].jjz.url, accounts[0].jjz.token
-    )
-    if not response_data or "error" in response_data:
-        logger.warning("查询进京证状态失败，跳过自动续办")
-        return
-
-    all_records = parse_all_jjz_records(
-        response_data, jjz_service._determine_status, JJZStatus
-    )
-
-    for plate_config in renew_plates:
-        plate = plate_config.plate
-        try:
-            # 从已解析的记录中找到匹配车牌的六环外最新记录
-            target_record = None
-            for record in all_records:
-                if record.plate.upper() == plate.upper():
-                    if record.jjzzlmc and "六环外" in record.jjzzlmc:
-                        if target_record is None or (record.apply_time or "") > (
-                            target_record.apply_time or ""
-                        ):
-                            target_record = record
-
-            if not target_record:
-                logger.info(f"车牌 {plate} 未找到六环外进京证记录")
-                continue
-
-            # 判断是否需要续办（有效期、待审记录等）
-            if not auto_renew_service.should_renew(plate_config, target_record):
-                logger.info(f"车牌 {plate} 不满足续办条件，跳过")
-                continue
-
-            # 需要续办但六环外不可办理时发通知
-            if target_record.elzsfkb is False:
-                await auto_renew_service.push_renew_result(
-                    plate_config,
-                    RenewResult(
-                        plate=plate,
-                        success=False,
-                        message="六环外进京证当前不可办理",
-                        step="eligibility_check",
-                    ),
-                )
-                continue
-
-            # 执行续办
-            renew_result = await auto_renew_service.execute_renew(
-                plate_config, target_record, response_data, accounts
-            )
-
-            # 推送结果
-            await auto_renew_service.push_renew_result(plate_config, renew_result)
-
-            logger.info(
-                f"车牌 {plate} 续办{'成功' if renew_result.success else '失败'}: "
-                f"{renew_result.message}"
-            )
-
-        except Exception as e:
-            logger.error(f"车牌 {plate} 自动续办异常: {e}")
-            await auto_renew_service.push_renew_result(
-                plate_config,
-                RenewResult(
-                    plate=plate,
-                    success=False,
-                    message=f"续办异常: {e}",
-                    step="exception",
-                ),
-            )

--- a/jjz_alert/service/jjz/auto_renew_service.py
+++ b/jjz_alert/service/jjz/auto_renew_service.py
@@ -464,5 +464,6 @@ class AutoRenewService:
             except Exception as e:
                 logger.error(f"续办结果推送失败: {e}")
 
+
 # 全局实例
 auto_renew_service = AutoRenewService()

--- a/jjz_alert/service/jjz/jjz_service.py
+++ b/jjz_alert/service/jjz/jjz_service.py
@@ -219,9 +219,7 @@ class JJZService:
                 plate=plate, status="error", error_message=str(e), data_source="api"
             )
 
-    async def _query_multiple_status(
-        self, plates: List[str]
-    ) -> Tuple[
+    async def _query_multiple_status(self, plates: List[str]) -> Tuple[
         Dict[str, JJZStatus],
         Dict[str, Tuple[Dict[str, Any], "JJZAccount", JJZStatus]],
     ]:
@@ -233,9 +231,7 @@ class JJZService:
         """
         results = {plate: None for plate in plates}
         accounts = self.load_accounts()
-        plate_contexts: Dict[
-            str, Tuple[Dict[str, Any], JJZAccount, JJZStatus]
-        ] = {}
+        plate_contexts: Dict[str, Tuple[Dict[str, Any], JJZAccount, JJZStatus]] = {}
 
         if not accounts:
             for plate in plates:
@@ -248,9 +244,9 @@ class JJZService:
             return results, plate_contexts
 
         # 同车牌可能出现在多账户里，记录三元组以便后续按 latest 同步选择正确账户
-        plate_statuses: Dict[str, List[Tuple[JJZStatus, Dict[str, Any], JJZAccount]]] = {
-            plate: [] for plate in plates
-        }
+        plate_statuses: Dict[
+            str, List[Tuple[JJZStatus, Dict[str, Any], JJZAccount]]
+        ] = {plate: [] for plate in plates}
 
         for account in accounts:
             try:
@@ -294,8 +290,7 @@ class JJZService:
 
                 # 续办用：仅从六环外记录中选最新一条；无六环外则不写入 plate_contexts
                 outer_triples = [
-                    t for t in triples
-                    if t[0].jjzzlmc and "六环外" in t[0].jjzzlmc
+                    t for t in triples if t[0].jjzzlmc and "六环外" in t[0].jjzzlmc
                 ]
                 if outer_triples:
                     renew_record, renew_response, renew_account = max(
@@ -335,9 +330,7 @@ class JJZService:
         default_return=({}, {}),
         recovery_config={"max_attempts": 2, "delay": 1.0},
     )
-    async def get_multiple_status_with_context(
-        self, plates: List[str]
-    ) -> Tuple[
+    async def get_multiple_status_with_context(self, plates: List[str]) -> Tuple[
         Dict[str, JJZStatus],
         Dict[str, Tuple[Dict[str, Any], "JJZAccount", JJZStatus]],
     ]:

--- a/jjz_alert/service/jjz/jjz_service.py
+++ b/jjz_alert/service/jjz/jjz_service.py
@@ -8,7 +8,7 @@ import asyncio
 import logging
 import time
 from datetime import datetime, date
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from jjz_alert.base.error_handler import (
     APIError,
@@ -219,18 +219,23 @@ class JJZService:
                 plate=plate, status="error", error_message=str(e), data_source="api"
             )
 
-    @with_error_handling(
-        exceptions=(APIError, NetworkError, ConfigurationError, Exception),
-        service_name="jjz_service",
-        default_return={},
-        recovery_config={"max_attempts": 2, "delay": 1.0},
-    )
-    async def get_multiple_status_optimized(
+    async def _query_multiple_status(
         self, plates: List[str]
-    ) -> Dict[str, JJZStatus]:
-        """优化的批量获取多个车牌的进京证状态 - 减少API调用次数"""
+    ) -> Tuple[
+        Dict[str, JJZStatus],
+        Dict[str, Tuple[Dict[str, Any], "JJZAccount", JJZStatus]],
+    ]:
+        """
+        内部实现：返回 (results, plate_contexts)。
+        plate_contexts 按车牌记录续办专用三元组 (response_data, account, renew_status)，
+        其中 renew_status 仅取该车牌六环外记录中 apply_time 最新的一条；若车牌无六环外记录则不写入。
+        多账户场景下保证后续续办派发使用正确账户与正确的六环外 status。
+        """
         results = {plate: None for plate in plates}
         accounts = self.load_accounts()
+        plate_contexts: Dict[
+            str, Tuple[Dict[str, Any], JJZAccount, JJZStatus]
+        ] = {}
 
         if not accounts:
             for plate in plates:
@@ -240,12 +245,13 @@ class JJZService:
                     error_message="未配置进京证账户",
                     data_source="api",
                 )
-            return results
+            return results, plate_contexts
 
-        # 记录每个车牌找到的状态
-        plate_statuses = {plate: [] for plate in plates}
+        # 同车牌可能出现在多账户里，记录三元组以便后续按 latest 同步选择正确账户
+        plate_statuses: Dict[str, List[Tuple[JJZStatus, Dict[str, Any], JJZAccount]]] = {
+            plate: [] for plate in plates
+        }
 
-        # 只遍历一次所有账户，为所有车牌收集数据
         for account in accounts:
             try:
                 logging.debug(f"使用账户 {account.name} 查询所有进京证数据")
@@ -259,32 +265,47 @@ class JJZService:
                     )
                     continue
 
-                # 解析所有进京证数据
                 all_records = parse_all_jjz_records(
                     response_data, self._determine_status, JJZStatus
                 )
 
-                # 为所有车牌查找匹配的记录
                 for record in all_records:
                     for plate in plates:
                         if record.plate.upper() == plate.upper():
-                            plate_statuses[plate].append(record)
+                            plate_statuses[plate].append(
+                                (record, response_data, account)
+                            )
 
             except Exception as e:
                 logging.warning(f"账户 {account.name} 查询失败: {e}")
                 continue
 
-        # 为每个车牌选择最新的状态并缓存
         for plate in plates:
-            statuses = plate_statuses[plate]
-            if statuses:
-                # 按申请时间排序，选择最新的记录
-                latest_status = max(statuses, key=lambda s: s.apply_time or "")
-                results[plate] = latest_status
+            triples = plate_statuses[plate]
+            if triples:
+                # 推送/显示用：所有记录中 apply_time 最新的一条
+                latest_record, latest_response, latest_account = max(
+                    triples, key=lambda t: t[0].apply_time or ""
+                )
+                results[plate] = latest_record
 
-                # 缓存成功查询的结果
-                if latest_status.status != JJZStatusEnum.ERROR.value:
-                    await self._cache_status(latest_status)
+                if latest_record.status != JJZStatusEnum.ERROR.value:
+                    await self._cache_status(latest_record)
+
+                # 续办用：仅从六环外记录中选最新一条；无六环外则不写入 plate_contexts
+                outer_triples = [
+                    t for t in triples
+                    if t[0].jjzzlmc and "六环外" in t[0].jjzzlmc
+                ]
+                if outer_triples:
+                    renew_record, renew_response, renew_account = max(
+                        outer_triples, key=lambda t: t[0].apply_time or ""
+                    )
+                    plate_contexts[plate] = (
+                        renew_response,
+                        renew_account,
+                        renew_record,
+                    )
             else:
                 results[plate] = JJZStatus(
                     plate=plate,
@@ -293,7 +314,39 @@ class JJZService:
                     data_source="api",
                 )
 
+        return results, plate_contexts
+
+    @with_error_handling(
+        exceptions=(APIError, NetworkError, ConfigurationError, Exception),
+        service_name="jjz_service",
+        default_return={},
+        recovery_config={"max_attempts": 2, "delay": 1.0},
+    )
+    async def get_multiple_status_optimized(
+        self, plates: List[str]
+    ) -> Dict[str, JJZStatus]:
+        """优化的批量获取多个车牌的进京证状态 - 减少API调用次数"""
+        results, _ = await self._query_multiple_status(plates)
         return results
+
+    @with_error_handling(
+        exceptions=(APIError, NetworkError, ConfigurationError, Exception),
+        service_name="jjz_service",
+        default_return=({}, {}),
+        recovery_config={"max_attempts": 2, "delay": 1.0},
+    )
+    async def get_multiple_status_with_context(
+        self, plates: List[str]
+    ) -> Tuple[
+        Dict[str, JJZStatus],
+        Dict[str, Tuple[Dict[str, Any], "JJZAccount", JJZStatus]],
+    ]:
+        """返回每个车牌对应的续办上下文 (response_data, account, renew_status)。
+
+        renew_status 仅取该车牌六环外记录中 apply_time 最新的一条；若无六环外记录则不写入。
+        多账户场景下保证后续续办派发使用正确账户。
+        """
+        return await self._query_multiple_status(plates)
 
     @with_retry(max_attempts=3, delay=1.0)
     async def _fetch_from_api(self, plate: str) -> JJZStatus:

--- a/jjz_alert/service/jjz/renew_decider.py
+++ b/jjz_alert/service/jjz/renew_decider.py
@@ -1,0 +1,77 @@
+"""
+自动续办决策器
+
+基于 PlateConfig + JJZStatus 决定续办分支：
+  SKIP / RENEW_TODAY / RENEW_TOMORROW / PENDING / NOT_AVAILABLE
+
+优先级：PENDING > NOT_AVAILABLE > RENEW_* > SKIP
+"""
+
+from datetime import date, timedelta
+from enum import Enum
+
+from jjz_alert.config.config_models import PlateConfig
+from jjz_alert.service.jjz.jjz_status import JJZStatus
+from jjz_alert.service.jjz.jjz_status_enum import JJZStatusEnum
+
+
+class RenewDecision(str, Enum):
+    SKIP = "skip"
+    RENEW_TODAY = "renew_today"
+    RENEW_TOMORROW = "renew_tomorrow"
+    PENDING = "pending"
+    NOT_AVAILABLE = "not_available"
+
+
+def decide(plate_config: PlateConfig, jjz_status: JJZStatus) -> RenewDecision:
+    """
+    决定一辆车在当前查询时刻的续办分支。
+
+    判断口径：以 jjz_status.valid_end 与本地 today/tomorrow 比较；
+    sfyecbzxx / elzsfkb 二次校验由 vehicle 级字段提供。
+    """
+    ar = plate_config.auto_renew
+    if not ar or not ar.enabled:
+        return RenewDecision.SKIP
+
+    # 续办仅支持六环外（execute_renew 固定 jjzzl="02"）；
+    # 当车牌最新记录不是六环外（jjzzlmc 缺失或不含"六环外"）时跳过
+    if not jjz_status.jjzzlmc or "六环外" not in jjz_status.jjzzlmc:
+        return RenewDecision.SKIP
+
+    if jjz_status.sfyecbzxx:
+        return RenewDecision.PENDING
+
+    if jjz_status.elzsfkb is False:
+        return RenewDecision.NOT_AVAILABLE
+
+    today = date.today()
+    tomorrow = today + timedelta(days=1)
+
+    valid_end_str = jjz_status.valid_end
+    valid_end_date = None
+    if valid_end_str:
+        try:
+            valid_end_date = date.fromisoformat(valid_end_str)
+        except (ValueError, TypeError):
+            valid_end_date = None
+
+    # INVALID 表示"无任何进京证记录"或解析失败，缺少 vId 等续办字段，
+    # 即使派发也会在 execute_renew 失败；与用户设计共识"不考虑无续办上下文"一致，
+    # 显式跳过避免无意义派发。
+    if jjz_status.status == JJZStatusEnum.EXPIRED.value:
+        return RenewDecision.RENEW_TODAY
+
+    if valid_end_date is None:
+        return RenewDecision.SKIP
+
+    if valid_end_date < today:
+        return RenewDecision.RENEW_TODAY
+
+    if valid_end_date < tomorrow:
+        return RenewDecision.RENEW_TOMORROW
+
+    return RenewDecision.SKIP
+
+
+__all__ = ["RenewDecision", "decide"]

--- a/jjz_alert/service/jjz/renew_trigger.py
+++ b/jjz_alert/service/jjz/renew_trigger.py
@@ -1,0 +1,112 @@
+"""
+自动续办派发器
+
+负责：
+1. 拟人化随机延迟（min_delay_seconds ~ max_delay_seconds）
+2. 全局锁串行执行 API 链（多车牌错峰，跨 loop/线程安全）
+3. 复用现有 Redis 当日防重 key
+4. 调用 execute_renew + push_renew_result
+"""
+
+import asyncio
+import logging
+import random
+import threading
+from datetime import date
+from typing import Any, Dict, List, Optional
+
+from jjz_alert.config.config_models import PlateConfig
+from jjz_alert.service.jjz.auto_renew_service import (
+    RenewResult,
+    auto_renew_service,
+)
+from jjz_alert.service.jjz.jjz_status import JJZStatus
+from jjz_alert.service.jjz.renew_decider import RenewDecision
+
+logger = logging.getLogger(__name__)
+
+# 跨事件循环/线程安全的全局锁
+# （asyncio.Semaphore 仅在单 loop 内安全，BlockingScheduler 每次触发都新建 loop，
+#  REST API 在独立线程也用自己 loop，必须用 threading.Lock + to_thread 抢锁）
+RENEW_GLOBAL_LOCK = threading.Lock()
+
+
+async def _has_renewed_today(plate: str) -> bool:
+    try:
+        from jjz_alert.config.redis.operations import redis_get
+
+        key = f"auto_renew:{plate}:{date.today().isoformat()}"
+        return (await redis_get(key)) is not None
+    except Exception:
+        return False
+
+
+async def schedule_renew(
+    plate_config: PlateConfig,
+    jjz_status: JJZStatus,
+    response_data: Dict[str, Any],
+    accounts: Optional[List[Any]],
+    decision: RenewDecision,
+    min_delay: int = 30,
+    max_delay: int = 180,
+) -> None:
+    """
+    异步派发一辆车的续办：随机延迟 → 抢全局锁 → 二次校验 → 执行续办 → 推送结果。
+    """
+    plate = plate_config.plate
+
+    if min_delay < 0:
+        min_delay = 0
+    if max_delay < min_delay:
+        max_delay = min_delay
+    delay = random.randint(min_delay, max_delay)
+
+    logger.info(
+        "[renew] dispatched plate=%s decision=%s delay=%ss",
+        plate,
+        decision.value,
+        delay,
+    )
+
+    try:
+        await asyncio.sleep(delay)
+    except asyncio.CancelledError:
+        logger.info("[renew] cancelled during sleep plate=%s", plate)
+        raise
+
+    # 用 threading.Lock 跨 loop 串行；await to_thread 让出协程并阻塞拿锁
+    await asyncio.to_thread(RENEW_GLOBAL_LOCK.acquire)
+    try:
+        if await _has_renewed_today(plate):
+            logger.info("[renew] skipped plate=%s reason=dedup_key_exists", plate)
+            return
+
+        try:
+            result = await auto_renew_service.execute_renew(
+                plate_config, jjz_status, response_data, accounts
+            )
+        except Exception as exc:
+            logger.error("[renew] execute_renew exception plate=%s: %s", plate, exc)
+            result = RenewResult(
+                plate=plate,
+                success=False,
+                message=f"续办异常: {exc}",
+                step="exception",
+            )
+
+        try:
+            await auto_renew_service.push_renew_result(plate_config, result)
+        except Exception as exc:
+            logger.error("[renew] push_renew_result failed plate=%s: %s", plate, exc)
+
+        logger.info(
+            "[renew] completed plate=%s success=%s step=%s",
+            plate,
+            result.success,
+            result.step,
+        )
+    finally:
+        RENEW_GLOBAL_LOCK.release()
+
+
+__all__ = ["RENEW_GLOBAL_LOCK", "schedule_renew"]

--- a/jjz_alert/service/jjz/renew_workflow.py
+++ b/jjz_alert/service/jjz/renew_workflow.py
@@ -91,9 +91,7 @@ async def run_renew_only_workflow() -> None:
                     ),
                 )
             except Exception as exc:
-                logger.error(
-                    f"[renew_only] 车牌 {plate} NOT_AVAILABLE 通知失败: {exc}"
-                )
+                logger.error(f"[renew_only] 车牌 {plate} NOT_AVAILABLE 通知失败: {exc}")
 
     # 等待派发协程完成（asyncio.create_task 已注册到当前 loop）
     pending = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]

--- a/jjz_alert/service/jjz/renew_workflow.py
+++ b/jjz_alert/service/jjz/renew_workflow.py
@@ -42,6 +42,7 @@ async def run_renew_only_workflow() -> None:
         return
 
     ar_global = app_config.global_config.auto_renew
+    dispatched_tasks: list = []
 
     for plate_config in renew_plates:
         plate = plate_config.plate
@@ -60,7 +61,7 @@ async def run_renew_only_workflow() -> None:
         if decision in (RenewDecision.RENEW_TODAY, RenewDecision.RENEW_TOMORROW):
             from jjz_alert.service.jjz.renew_trigger import schedule_renew
 
-            asyncio.create_task(
+            task = asyncio.create_task(
                 schedule_renew(
                     plate_config,
                     ctx_renew_status,
@@ -71,6 +72,7 @@ async def run_renew_only_workflow() -> None:
                     max_delay=ar_global.max_delay_seconds,
                 )
             )
+            dispatched_tasks.append(task)
             logger.info(
                 f"[renew_only] decision plate={plate} -> {decision.value} 已派发"
             )
@@ -93,10 +95,9 @@ async def run_renew_only_workflow() -> None:
             except Exception as exc:
                 logger.error(f"[renew_only] 车牌 {plate} NOT_AVAILABLE 通知失败: {exc}")
 
-    # 等待派发协程完成（asyncio.create_task 已注册到当前 loop）
-    pending = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
-    if pending:
-        await asyncio.gather(*pending, return_exceptions=True)
+    # 仅等待本工作流派发的任务，避免在共享 loop 场景下误等其他任务
+    if dispatched_tasks:
+        await asyncio.gather(*dispatched_tasks, return_exceptions=True)
 
 
 __all__ = ["run_renew_only_workflow"]

--- a/jjz_alert/service/jjz/renew_workflow.py
+++ b/jjz_alert/service/jjz/renew_workflow.py
@@ -1,0 +1,104 @@
+"""
+仅续办工作流：批量查询 stateList → 决策 → 派发，不发任何状态/限行推送。
+
+仅供"用户禁用 remind 但启用 auto_renew"场景下的兜底 cron 使用。
+remind 启用时由 push_workflow 完成同样的决策+派发链路（同时含状态推送）。
+"""
+
+import asyncio
+import logging
+
+from jjz_alert.config.config import config_manager
+from jjz_alert.service.cache.cache_service import CacheService
+from jjz_alert.service.jjz.jjz_service import JJZService
+from jjz_alert.service.jjz.renew_decider import RenewDecision, decide
+
+logger = logging.getLogger(__name__)
+
+
+async def run_renew_only_workflow() -> None:
+    """
+    仅执行续办决策与派发，不推送状态/限行通知。
+    用于 remind 关闭但 auto_renew 启用时的凌晨兜底 cron。
+    """
+    app_config = config_manager.load_config()
+    renew_plates = [
+        p for p in app_config.plates if p.auto_renew and p.auto_renew.enabled
+    ]
+    if not renew_plates:
+        logger.debug("[renew_only] 无启用自动续办的车牌，跳过")
+        return
+
+    plate_numbers = [p.plate for p in renew_plates]
+    cache_service = CacheService()
+    jjz_service = JJZService(cache_service)
+
+    try:
+        all_jjz_results, plate_renew_contexts = (
+            await jjz_service.get_multiple_status_with_context(plate_numbers)
+        )
+    except Exception as exc:
+        logger.error(f"[renew_only] 批量查询进京证状态失败: {exc}")
+        return
+
+    ar_global = app_config.global_config.auto_renew
+
+    for plate_config in renew_plates:
+        plate = plate_config.plate
+        ctx = plate_renew_contexts.get(plate)
+        if ctx is None:
+            logger.debug(f"[renew_only] 车牌 {plate} 缺少续办上下文，跳过")
+            continue
+        ctx_response_data, ctx_account, ctx_renew_status = ctx
+
+        try:
+            decision = decide(plate_config, ctx_renew_status)
+        except Exception as exc:
+            logger.warning(f"[renew_only] 车牌 {plate} 决策异常: {exc}")
+            continue
+
+        if decision in (RenewDecision.RENEW_TODAY, RenewDecision.RENEW_TOMORROW):
+            from jjz_alert.service.jjz.renew_trigger import schedule_renew
+
+            asyncio.create_task(
+                schedule_renew(
+                    plate_config,
+                    ctx_renew_status,
+                    ctx_response_data,
+                    [ctx_account],
+                    decision,
+                    min_delay=ar_global.min_delay_seconds,
+                    max_delay=ar_global.max_delay_seconds,
+                )
+            )
+            logger.info(
+                f"[renew_only] decision plate={plate} -> {decision.value} 已派发"
+            )
+        elif decision == RenewDecision.NOT_AVAILABLE:
+            try:
+                from jjz_alert.service.jjz.auto_renew_service import (
+                    auto_renew_service,
+                    RenewResult,
+                )
+
+                await auto_renew_service.push_renew_result(
+                    plate_config,
+                    RenewResult(
+                        plate=plate,
+                        success=False,
+                        message="六环外进京证当前不可办理",
+                        step="eligibility_check",
+                    ),
+                )
+            except Exception as exc:
+                logger.error(
+                    f"[renew_only] 车牌 {plate} NOT_AVAILABLE 通知失败: {exc}"
+                )
+
+    # 等待派发协程完成（asyncio.create_task 已注册到当前 loop）
+    pending = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
+    if pending:
+        await asyncio.gather(*pending, return_exceptions=True)
+
+
+__all__ = ["run_renew_only_workflow"]

--- a/jjz_alert/service/notification/jjz_push_service.py
+++ b/jjz_alert/service/notification/jjz_push_service.py
@@ -170,8 +170,11 @@ class JJZPushService:
                     for plate in configured_plates:
                         await self.cache_service.delete_jjz_data(plate)
 
-                # 使用优化的批量查询
-                all_jjz_results = await self.jjz_service.get_multiple_status_optimized(
+                # 使用带上下文的批量查询，复用 raw response_data 给自动续办派发器
+                (
+                    all_jjz_results,
+                    plate_renew_contexts,
+                ) = await self.jjz_service.get_multiple_status_with_context(
                     configured_plates
                 )
 
@@ -381,6 +384,75 @@ class JJZPushService:
 
                     plate_result["jjz_status"] = jjz_status.to_dict()
 
+                    # 自动续办决策：命中 RENEW_* 时异步派发续办协程，并抑制冲突的"催办"提醒
+                    # 决策必须基于 ctx.renew_status（仅六环外）以避免被同车牌的六环内最新记录干扰
+                    renew_dispatched = False
+                    decision = None
+                    ctx = plate_renew_contexts.get(plate)
+                    if ctx is None:
+                        # 没有六环外续办上下文 → 跳过派发（车牌可能仅有六环内或完全无记录）
+                        ctx_response_data = None
+                        ctx_account = None
+                        ctx_renew_status = None
+                    else:
+                        ctx_response_data, ctx_account, ctx_renew_status = ctx
+                        try:
+                            from jjz_alert.service.jjz.renew_decider import (
+                                RenewDecision,
+                                decide,
+                            )
+
+                            decision = decide(plate_config, ctx_renew_status)
+                        except Exception as e:
+                            logging.warning(f"车牌 {plate} 续办决策异常: {e}")
+                            decision = None
+
+                    if ctx is not None and decision in (
+                        RenewDecision.RENEW_TODAY,
+                        RenewDecision.RENEW_TOMORROW,
+                    ):
+                        try:
+                            from jjz_alert.service.jjz.renew_trigger import (
+                                schedule_renew,
+                            )
+
+                            ar_global = app_config.global_config.auto_renew
+                            asyncio.create_task(
+                                schedule_renew(
+                                    plate_config,
+                                    ctx_renew_status,
+                                    ctx_response_data,
+                                    [ctx_account],
+                                    decision,
+                                    min_delay=ar_global.min_delay_seconds,
+                                    max_delay=ar_global.max_delay_seconds,
+                                )
+                            )
+                            renew_dispatched = True
+                            logging.info(
+                                f"[renew] decision plate={plate} -> {decision.value} 已派发"
+                            )
+                        except Exception as e:
+                            logging.error(f"车牌 {plate} 续办派发失败: {e}")
+                    elif ctx is not None and decision == RenewDecision.NOT_AVAILABLE:
+                        try:
+                            from jjz_alert.service.jjz.auto_renew_service import (
+                                auto_renew_service,
+                                RenewResult,
+                            )
+
+                            await auto_renew_service.push_renew_result(
+                                plate_config,
+                                RenewResult(
+                                    plate=plate,
+                                    success=False,
+                                    message="六环外进京证当前不可办理",
+                                    step="eligibility_check",
+                                ),
+                            )
+                        except Exception as e:
+                            logging.error(f"车牌 {plate} NOT_AVAILABLE 通知失败: {e}")
+
                     # 获取限行状态
                     traffic_result = all_traffic_results.get(plate)
                     if traffic_result:
@@ -458,10 +530,19 @@ class JJZPushService:
                                 jjz_status.valid_end
                                 and jjz_status.valid_end <= today_str
                             ):
-                                warn_msg = f"车牌 {plate} 明日尚未查询到进京证信息，请注意及时办理进京证。"
-                                push_result = await push_jjz_reminder(
-                                    plate_config, warn_msg, priority=PushPriority.HIGH
-                                )
+                                if renew_dispatched:
+                                    # 已派发自动续办，抑制冲突提醒
+                                    push_result = {
+                                        "success": True,
+                                        "skipped": "renew_dispatched",
+                                    }
+                                else:
+                                    warn_msg = f"车牌 {plate} 明日尚未查询到进京证信息，请注意及时办理进京证。"
+                                    push_result = await push_jjz_reminder(
+                                        plate_config,
+                                        warn_msg,
+                                        priority=PushPriority.HIGH,
+                                    )
                             else:
                                 push_result = {
                                     "success": True,

--- a/jjz_alert/service/notification/jjz_push_service.py
+++ b/jjz_alert/service/notification/jjz_push_service.py
@@ -20,6 +20,7 @@ from jjz_alert.service.cache.cache_service import CacheService
 from jjz_alert.service.homeassistant.ha_mqtt import ha_mqtt_publisher
 from jjz_alert.service.jjz.jjz_service import JJZService
 from jjz_alert.service.jjz.jjz_status_enum import JJZStatusEnum
+from jjz_alert.service.jjz.renew_decider import RenewDecision, decide as renew_decide
 from jjz_alert.service.notification.batch_pusher import (
     batch_pusher,
     BatchPushItem,
@@ -397,12 +398,7 @@ class JJZPushService:
                     else:
                         ctx_response_data, ctx_account, ctx_renew_status = ctx
                         try:
-                            from jjz_alert.service.jjz.renew_decider import (
-                                RenewDecision,
-                                decide,
-                            )
-
-                            decision = decide(plate_config, ctx_renew_status)
+                            decision = renew_decide(plate_config, ctx_renew_status)
                         except Exception as e:
                             logging.warning(f"车牌 {plate} 续办决策异常: {e}")
                             decision = None

--- a/main.py
+++ b/main.py
@@ -162,6 +162,30 @@ def schedule_jobs():
             finally:
                 loop.close()
 
+    def async_renew_only_wrapper():
+        """Wrapper 仅执行续办决策与派发，不发状态推送通知"""
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        try:
+            from jjz_alert.service.jjz.renew_workflow import (
+                run_renew_only_workflow,
+            )
+
+            loop.run_until_complete(run_renew_only_workflow())
+        except Exception as e:
+            logging.error(f"自动续办兜底任务失败: {e}")
+        finally:
+            try:
+                pending = asyncio.all_tasks(loop)
+                if pending:
+                    loop.run_until_complete(
+                        asyncio.gather(*pending, return_exceptions=True)
+                    )
+            except Exception as e:
+                logging.warning(f"清理续办兜底任务时出错: {e}")
+            finally:
+                loop.close()
+
     # 仅在提醒功能启用时注册提醒定时任务
     remind_enabled = (
         app_config.global_config.remind.enable
@@ -180,46 +204,28 @@ def schedule_jobs():
             )
             logging.info(f"已添加定时任务: 每天 {hour:02d}:{minute:02d}")
 
-    # 注册自动续办定时任务（每天 00:00 触发）
-    renew_plates = [
-        p for p in app_config.plates if p.auto_renew and p.auto_renew.enabled
-    ]
-    if renew_plates:
+    # 自动续办由 remind cron 触发的查询流程驱动（参见 renew_decider + renew_trigger），
+    # 不再注册独立的 cron 任务。
 
-        def async_renew_wrapper():
-            """Wrapper to run auto renew check in sync scheduler"""
-            loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(loop)
-            try:
-                from jjz_alert.service.jjz.auto_renew_service import (
-                    run_auto_renew_check,
-                )
-
-                loop.run_until_complete(run_auto_renew_check())
-            except Exception as e:
-                logging.error(f"自动续办任务执行失败: {e}")
-            finally:
-                try:
-                    pending = asyncio.all_tasks(loop)
-                    if pending:
-                        loop.run_until_complete(
-                            asyncio.gather(*pending, return_exceptions=True)
-                        )
-                except Exception as e:
-                    logging.warning(f"清理自动续办待处理任务时出错: {e}")
-                finally:
-                    loop.close()
-
+    has_auto_renew_plates = any(
+        p.auto_renew and p.auto_renew.enabled for p in app_config.plates
+    )
+    # 判断 remind.times 中是否已有凌晨（00:00-04:00）时刻；
+    # 若无且启用了自动续办，注册 00:30 兜底 cron——确保 23:55 触发后
+    # 北京交管放号失败的车辆能在凌晨重试，不必等到次日白天 remind
+    has_post_midnight_remind = remind_enabled and any(
+        int(t.split(":")[0]) < 4 for t in remind_times if ":" in t
+    )
+    if has_auto_renew_plates and not has_post_midnight_remind:
         scheduler.add_job(
-            async_renew_wrapper,
-            CronTrigger(hour=0, minute=0),
-            misfire_grace_time=3600,  # 最多延迟1小时执行，避免深夜误触发
+            async_renew_only_wrapper,
+            CronTrigger(hour=0, minute=30),
+            misfire_grace_time=3600,
             max_instances=1,
         )
         logging.info(
-            f"已添加自动续办定时任务: 每天 00:00 "
-            f"(随机窗口 {app_config.global_config.auto_renew.time_window_start}"
-            f"-{app_config.global_config.auto_renew.time_window_end})"
+            "已注册自动续办凌晨兜底任务: 每天 00:30"
+            "（仅决策+派发续办，不推送状态通知）"
         )
 
     logging.info("定时任务调度器启动")
@@ -255,13 +261,12 @@ if __name__ == "__main__":
         except ImportError:
             logging.warning("REST API 模块不可用，跳过API服务启动")
 
-    # 检查是否有启用自动续办的车牌
     has_auto_renew = any(
         p.auto_renew and p.auto_renew.enabled for p in app_config.plates
     )
 
     if remind_enabled or has_auto_renew:
-        # 启动定时任务（阻塞）— 包含提醒和/或自动续办
+        # 启动定时任务（阻塞）—— remind 触发查询并按需派发续办
         schedule_jobs()
     else:
         # 仅执行一次查询

--- a/openspec/changes/auto-renew-event-driven/.openspec.yaml
+++ b/openspec/changes/auto-renew-event-driven/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-03

--- a/openspec/changes/auto-renew-event-driven/design.md
+++ b/openspec/changes/auto-renew-event-driven/design.md
@@ -1,0 +1,211 @@
+## 上下文
+
+**当前状态**
+
+自动续办作为独立 cron 任务运行：APScheduler 每天 00:00 触发 → `calculate_random_delay()` 在 `time_window_start`–`time_window_end`（默认 00:00–06:00）窗口内随机一个时刻 → `run_auto_renew_check()` 重新调用 `stateList` → 对每辆启用续办的车牌调用 `should_renew()` 判断（条件：六环外 + 无待审 + `valid_end <= tomorrow`）→ 调续办 6 步 API 链。
+
+与此同时，提醒推送（remind）作为另一个独立 cron 任务（默认 07:00 / 12:30 / 19:00 / 23:55）也在调用 `stateList`，并在 `process_single_plate` 内已有"次日有效性"判断（`jjz_push_service.py:419-469`），但仅用来发送 `push_jjz_reminder` 文字提醒，不参与续办。
+
+**约束**
+
+- 续办 API 链每步耗时数百 ms 至 1 s，且对北京交管接口需要拟人化以避免风控。
+- `JJZService.get_multiple_status_optimized()` 对每辆车返回 `max(records, key=apply_time)` 的"最新一条"——不一定是六环外，但 `vId`/`elzsfkb`/`sfyecbzxx` 等续办所需字段是 vehicle 级，与具体记录类型无关。
+- 续办接口以 `jjzzl="02"` 固定提交六环外，与 `jjz_status` 的具体记录类型解耦。
+- 服务可能在任意时间被重启（容器重部署、SIGTERM）。
+
+**利益相关者**
+
+- 终端用户：希望"快到期/已过期就立即办"，而不是死等凌晨窗口。
+- 开发者：维护成本低，配置项语义清晰。
+- 北京交管接口：低频、拟人化、错峰。
+
+## 目标 / 非目标
+
+**目标：**
+
+- 把续办触发与"发现状态"的时刻对齐：任意 remind 时刻发现"明天没证 / 今天没证"都可以立即派发续办。
+- 复用 remind 已经查到的 `stateList` 数据，避免重复调用。
+- 多车牌触发时通过随机延迟 + 全局信号量错峰，避免并发请求。
+- 失败重试的语义降级到"等下一个 remind 时刻自然重试"，不引入额外重试机制。
+- 删除冗余配置（`time_window_*`），引入语义清晰的延迟范围配置。
+
+**非目标：**
+
+- 不实现"服务启动即触发"——继续依赖 remind cron 的自然节奏。
+- 不为"完全无六环外历史"的车牌做特殊路径——这种情况 `vId` 为空，续办流程会在 `validate_fields` 步骤自然失败并通知，无需额外分支。
+- 不引入分布式锁——单进程部署 + Redis 当日防重 + `sfyecbzxx` 二次校验已经足够。
+- 不改变续办 API 调用链本身（6 步 API 顺序、字段组装、Token 失效识别等保持不变）。
+- 不调整 remind 的 cron 时刻——用户已有的 `remind.times` 配置不变。
+
+## 决策
+
+### 决策 1：决策器返回枚举，而非布尔
+
+**选择**：新建 `RenewDecision(Enum)`，包含 `SKIP` / `RENEW_TODAY` / `RENEW_TOMORROW` / `PENDING` / `NOT_AVAILABLE`。
+
+**理由**：
+
+- 旧 `should_renew()` 返回布尔，无法区分"为什么不办"——`PENDING`（已有待审）与 `NOT_AVAILABLE`（六环外不可办）需要不同处理（前者静默，后者发告警）。
+- `RENEW_TODAY` / `RENEW_TOMORROW` 的区分让日志和通知更精准，也让未来的策略调优（例如对 `RENEW_TODAY` 缩短延迟）成为可能。
+
+**替代方案**：
+
+- *保留 `should_renew()` 返回 bool，调用方自己拆条件* — 拆分条件会散落在多处，难以测试。
+- *返回 dataclass 携带更多上下文* — 当前只需要枚举级信息，dataclass 是过度设计。
+
+### 决策 2：决策矩阵以 `valid_end` 为唯一时间字段
+
+**选择**：
+
+```
+SKIP                : valid_start <= today AND today < tomorrow <= valid_end
+RENEW_TOMORROW      : valid_start <= today <= valid_end AND tomorrow > valid_end
+RENEW_TODAY         : valid_end < today  OR  status == EXPIRED / INVALID
+PENDING             : sfyecbzxx == True
+NOT_AVAILABLE       : elzsfkb == False
+```
+
+优先级：`PENDING` > `NOT_AVAILABLE` > `RENEW_*` > `SKIP`。
+
+**理由**：
+
+- `jjz_status.valid_end` 是 push_workflow 已经在用的字段（`jjz_push_service.py:455-464`），新决策器与现有"次日提醒"判断完全等价，避免引入第二套真值判断。
+- 不需要识别"哪条记录是六环外"——`vId` 等续办字段是 vehicle 级的，已经统一。
+
+**替代方案**：
+
+- *用 `days_remaining` 字段* — 该字段是接口返回的 `sxsyts`，依赖接口侧时区/计算口径，不如本地比 `today` 可靠。
+- *按"六环外历史 vs 六环内历史"分别判断* — 用户已确认不区分，简化逻辑。
+
+### 决策 3：派发用 `asyncio.create_task` fire-and-forget
+
+**选择**：在 `process_single_plate` 内决策命中 `RENEW_*` 时执行：
+
+```python
+asyncio.create_task(schedule_renew(plate_config, jjz_status, response_data, accounts, decision))
+```
+
+不 await，让 push_workflow 主流程立刻返回。
+
+**理由**：
+
+- `schedule_renew` 内部要 `sleep(30~180s)`，await 会把 push_workflow 整体阻塞到分钟级。
+- 续办失败/成功都通过独立通知告知用户，不需要主流程感知结果。
+
+**替代方案**：
+
+- *await 直接执行* — 阻塞主流程；多车牌串行后总耗时不可接受。
+- *写入 Redis 队列由独立 worker 消费* — 引入额外组件，单进程场景过度。
+
+**风险**：进程在 sleep 期间被 SIGTERM 时任务丢失 → 由"下一个 remind 时刻自然重试"兜底。
+
+### 决策 4：错峰用 `asyncio.Semaphore(1)` 全局串行
+
+**选择**：模块级 `RENEW_GLOBAL_SEMAPHORE = asyncio.Semaphore(1)`，`schedule_renew` 在 sleep 醒来后 `async with` 抢锁，再调 `execute_renew`。
+
+**理由**：
+
+- 多车牌同时命中场景②时，即便随机延迟有重叠（30~180s 内有概率撞），信号量保证任意时刻只有 1 条续办 API 链在跑。
+- API 链耗时数秒，4 辆车串行也只多花十几秒，可接受。
+- 比"按车牌索引分配偏移"实现更简单、更稳健。
+
+**替代方案**：
+
+- *只靠随机延迟* — 4 辆车随机到接近时刻的概率不低，单纯依赖 30~180s 区间错峰不够强。
+- *Redis 分布式锁* — 单进程足够，分布式锁是过度工程。
+
+### 决策 5：抑制冲突的 reminder 通知
+
+**选择**：`process_single_plate` 命中 `RENEW_TODAY` / `RENEW_TOMORROW` 时跳过 `push_jjz_reminder("请注意及时办理...")`，把 `push_result` 设为 `{"success": True, "skipped": "renew_dispatched"}`。续办协程结束时通过 `push_renew_result` 单独发结果通知。
+
+**理由**：
+
+- 旧实现下用户在场景①会同时收到"请注意及时办理"和"续办成功"两条通知，互相矛盾。
+- 命中 `NOT_AVAILABLE`（六环外不可办）时**仍发**告警——这是机器无法处理的情况，必须让用户知晓。
+- 命中 `PENDING` 时**保留**正常通知（已有待审记录其实是"好消息"）。
+
+**替代方案**：
+
+- *永远抑制提醒，只看续办结果* — 决策为 `NOT_AVAILABLE` 时用户会沉默，不可接受。
+
+### 决策 6：失败重试 = 等下一个 remind 时刻
+
+**选择**：`checkHandle` 返回空 `jjrqs`（接口未放号）时：
+
+- `RenewResult.success = False`、`step = "check_handle"`
+- **不写**当日防重 Redis key
+- 通过 `push_renew_result` 通知用户
+- 下一个 remind 时刻 push_workflow 会重新决策并派发
+
+**理由**：
+
+- 北京交管"明日额度"通常 0 点放号，但偶有延迟。在 23:55 触发时若未放号，等 5 分钟后的下一个 cron 自然就过 0 点了。
+- 不需要在续办协程内做指数退避或多次轮询，简化逻辑。
+
+**替代方案**：
+
+- *续办协程内重试 N 次* — 增加复杂度，且阻塞信号量更长时间。
+- *写入 Redis 标记"待重试"由后台扫描* — 与 remind cron 重试等价但更复杂。
+
+### 决策 7：配置字段替换 + 旧字段降级警告
+
+**选择**：
+
+- BREAKING 删除 `global.auto_renew.time_window_start` / `time_window_end`。
+- 新增 `global.auto_renew.min_delay_seconds`（默认 30）/ `max_delay_seconds`（默认 180）。
+- 配置加载时若检测到旧字段，记录 WARN 日志（"已废弃，将被忽略"），不阻塞启动。
+
+**理由**：
+
+- 旧字段语义在新模型下完全失效，无法 graceful 映射为新字段（窗口起止与延迟范围不是同一概念）。
+- WARN + 默认值兜底，避免用户升级后服务直接挂掉。
+
+**替代方案**：
+
+- *保留旧字段作为别名* — 语义不一致，徒增混乱。
+- *在 validation 里硬错* — 用户升级体验差。
+
+### 决策 8：`response_data` / `accounts` 从 `JJZService` 传出
+
+**选择**：扩展 `JJZService.get_multiple_status_optimized()` 的返回值（或新增配套方法）让调用方拿到原始 `response_data` 与 `accounts`，而不是让 `schedule_renew` 内部重新查 `stateList`。
+
+**理由**：
+
+- 重新查会多一次接口调用，增加风控风险，且 push_workflow 已经查过了。
+- `response_data` 是 `extract_renew_metadata`（`elzqyms` / `elzmc` 等）的来源，必须传递。
+
+**替代方案**：
+
+- *renew 内重查* — 浪费请求 + 多走一次反爬延迟。
+- *把 `response_data` 缓存到 Redis 让 renew 读取* — 跨进程不需要，纯内存传递更简单。
+
+实现细节：可以让 `get_multiple_status_optimized` 增加一个 out 参数，或者新增 `get_multiple_status_with_raw()` 方法返回元组。具体方式在实现阶段决定，但接口契约是"调用方能拿到 raw response_data 和 accounts"。
+
+## 风险 / 权衡
+
+| 风险 | 缓解 |
+|------|------|
+| 进程在 sleep 期间被 SIGTERM，续办丢失 | 下一个 remind 时刻 push_workflow 重新决策并派发；用户最差等 4–6 小时（按默认 remind.times） |
+| `checkHandle` 返回的日期不是预期的（场景①拿到今日、场景②拿到明日） | `execute_renew` 仍按 `jjrqs[0]` 提交；与现状一致，不增加新风险 |
+| 多车牌错峰下信号量抢不到导致 sleep 超过 max_delay | 信号量 acquire 不设超时，最坏情况 N 辆车依次跑，总耗时 N × (random_delay + api_chain) ≈ N × 3 分钟，可接受 |
+| 用户升级后未更新配置，旧字段 `time_window_*` 仍写在 yaml 里 | 启动 WARN 日志 + 默认值兜底，行为正确但用户能看到提示 |
+| `RENEW_TOMORROW` 在 23:55 触发时接口未放号导致首次失败 | 失败仅一次提醒（`push_renew_result`），下一个 cron（00:00 之后）自然重试，用户体验可接受 |
+| 现有 push_workflow 内并发调用 `process_single_plate`，多个车牌同时 `create_task` | 信号量保证 API 链串行；`asyncio.create_task` 本身线程安全 |
+| 移除旧 `should_renew` 后单元测试覆盖中断 | 在 `tests/test_renew_decider.py` 里完整覆盖决策矩阵；`tests/test_auto_renew.py` 调整为新派发器的集成测试 |
+
+## 迁移计划
+
+**部署步骤**
+
+1. 合并代码后，启动时若检测到旧 `time_window_*` 字段，输出 WARN 日志。
+2. 用户在升级文档中按指引把 `global.auto_renew.time_window_start/end` 替换为 `min_delay_seconds/max_delay_seconds`（或直接删除，使用默认值）。
+3. 验证：观察首日 remind 触发时是否有续办派发日志（检索 `[renew] decision=...` 与 `[renew] dispatched plate=...`）。
+
+**回滚策略**
+
+- 单 commit revert 即可恢复旧 cron 行为；旧 `time_window_*` 配置字段仍在 yaml 里时不影响 revert（旧代码会重新读到它们）。
+- 用户的 Redis dedup key (`auto_renew:{plate}:{date}`) 与新旧实现兼容，无需清理。
+
+## 待解决问题
+
+无。所有决策点已与用户对齐确认。

--- a/openspec/changes/auto-renew-event-driven/proposal.md
+++ b/openspec/changes/auto-renew-event-driven/proposal.md
@@ -1,0 +1,55 @@
+## 为什么
+
+当前自动续办由独立的 cron 任务驱动，固定每天 00:00 触发并在 `time_window_start` ~ `time_window_end`（默认 00:00–06:00）窗口内随机延迟执行。这带来两类问题：
+
+1. **触发时机与状态发现脱钩**：续办判断仅在凌晨窗口运行一次，错过窗口（例如服务在 06:01 后才上线、或 cron 因 misfire 跳过）就要等 24 小时；而 remind 任务在白天明明已经查到"明天没有进京证"，却无法直接触发续办。
+2. **重复查询**：remind 任务和续办任务都独立调用一次 `stateList` 接口拿同一份数据，浪费请求且彼此不知情。
+
+将续办从"定时驱动"重构为"事件驱动"——挂在已有的 remind 查询流程上，按当前/次日有效性分场景触发。
+
+## 变更内容
+
+- **改造续办触发机制**：删除独立的自动续办 cron 任务，改为在 `JJZPushService.process_single_plate` 拿到 `jjz_status` 后调用决策器分类，命中即 `asyncio.create_task` 异步派发续办。
+- **新增续办决策器** `RenewDecision` 枚举与 `decide()` 函数，按"今日/明日有效性 + `sfyecbzxx` + `elzsfkb`"返回 `SKIP`/`RENEW_TODAY`/`RENEW_TOMORROW`/`PENDING`/`NOT_AVAILABLE`。
+- **新增续办派发器** `schedule_renew()`：随机延迟（拟人化反爬，默认 30–180s）+ 全局 `asyncio.Semaphore(1)` 串行（多车牌错峰）+ 复用现有 Redis 当日防重 key。
+- **抑制冲突提醒**：决策命中 `RENEW_TODAY` / `RENEW_TOMORROW` 时跳过原本的 `push_jjz_reminder`，改由续办协程结束后通过 `push_renew_result` 单独通知。
+- **简化失败重试**：`checkHandle` 返回空 `jjrqs` 时本次失败但**不写**当日防重 key，下一个 remind 时刻自然重试。
+- **BREAKING** 删除 `global.auto_renew.time_window_start` 和 `global.auto_renew.time_window_end` 配置项；新增 `global.auto_renew.min_delay_seconds`（默认 30）和 `global.auto_renew.max_delay_seconds`（默认 180）。
+- **删除遗留代码**：`run_auto_renew_check()`、`should_renew()`、`calculate_random_delay()`、`main.py` 中的自动续办 cron 注册分支、`_validate_auto_renew_time_window` 校验。
+
+## 功能 (Capabilities)
+
+### 新增功能
+
+无。
+
+### 修改功能
+
+- `auto-renew`: 触发判断从"端到端 cron + 凌晨随机窗口"改为"事件驱动 + 分场景决策 + 拟人化延迟 + 全局错峰"；新增"提醒抑制"语义；失败重试改为下一个 remind 时刻重试。
+- `renew-config`: 删除"全局续办时间窗口配置"需求；新增"全局续办延迟配置"需求（`min_delay_seconds` / `max_delay_seconds`）。
+
+## 影响
+
+**代码**
+
+- 新增：`jjz_alert/service/jjz/renew_decider.py`（`RenewDecision` 枚举 + `decide()`）、`jjz_alert/service/jjz/renew_trigger.py`（`schedule_renew()` + 全局信号量）。
+- 修改：`jjz_alert/service/jjz/auto_renew_service.py`（删 `run_auto_renew_check` / `should_renew` / `calculate_random_delay`，保留 `execute_renew` 与 `push_renew_result`）。
+- 修改：`jjz_alert/service/notification/jjz_push_service.py`（`process_single_plate` 末尾接入决策与派发；`response_data` 与 `accounts` 需要从 `JJZService` 传出）。
+- 修改：`main.py`（删除自动续办 cron 注册；`has_auto_renew` 启动判断简化）。
+- 修改：`jjz_alert/config/config_models.py`、`jjz_alert/config/config.py`、`jjz_alert/config/validation.py`（配置字段替换 + 校验调整）。
+
+**配置**
+
+- BREAKING: `config.yaml` 中 `global.auto_renew.time_window_start` / `time_window_end` 无效；用户需替换为 `min_delay_seconds` / `max_delay_seconds`（启动时若检测到旧字段，给出 WARN 日志并使用默认值）。
+- 更新 `config.yaml.example`。
+
+**测试**
+
+- 新增 `tests/test_renew_decider.py`（决策矩阵覆盖）。
+- 更新 `tests/test_auto_renew.py`（删除旧触发链路测试，新增 `schedule_renew` 集成测试，包括信号量串行行为）。
+- 更新 `tests/test_config.py`（配置字段替换覆盖）。
+
+**运行时**
+
+- 续办派发为 `asyncio.create_task` fire-and-forget；进程在 sleep 期间收到 SIGTERM 时未完成的续办会丢失，但下一个 remind 时刻会重新决策并重试。
+- 续办协程的随机延迟 + 全局信号量替代了原本的"凌晨窗口"语义。

--- a/openspec/changes/auto-renew-event-driven/specs/auto-renew/spec.md
+++ b/openspec/changes/auto-renew-event-driven/specs/auto-renew/spec.md
@@ -1,0 +1,110 @@
+## 新增需求
+
+### 需求:续办触发抑制冲突提醒
+当某车牌的续办决策为续办今日（`RENEW_TODAY`）或续办明日（`RENEW_TOMORROW`）时，系统必须抑制原本会发送的"明日尚未查询到进京证信息"或同类用户提醒，以避免与续办结果通知形成语义冲突；续办协程结束后必须通过 `push_renew_result` 单独发送结果通知。
+
+#### 场景:命中续办时抑制提醒
+- **当** `process_single_plate` 调用决策器返回 `RENEW_TODAY` 或 `RENEW_TOMORROW`
+- **那么** 系统必须跳过 `push_jjz_reminder` 调用，且本次车牌处理结果中标记 `skipped=renew_dispatched`
+- **并且** 系统必须通过 `asyncio.create_task` 异步派发续办协程，由协程结束时单独推送续办结果通知
+
+#### 场景:命中NOT_AVAILABLE仍发送告警
+- **当** 决策器返回 `NOT_AVAILABLE`（六环外不可办）
+- **那么** 系统必须按现有逻辑推送"六环外进京证当前不可办理"告警，不得抑制
+
+#### 场景:命中PENDING保留正常通知
+- **当** 决策器返回 `PENDING`（已有待审记录）
+- **那么** 系统必须按正常分支推送进京证状态通知，不得抑制
+
+### 需求:多账户上下文隔离
+当配置了多个 JJZ 账户时，系统必须按车牌记录每条记录对应的 (response_data, account) 上下文，并在派发续办时使用该车牌专属的账户 token 与原始响应，禁止跨账户混用。
+
+#### 场景:不同账户车牌使用各自账户上下文
+- **当** 车牌 A 的进京证记录来自账户 1，车牌 B 的进京证记录来自账户 2
+- **那么** 系统派发 A 的续办协程时必须使用账户 1 的 token、URL 与原始 stateList 响应；派发 B 时必须使用账户 2 的对应数据
+
+#### 场景:车牌缺少账户上下文时跳过派发
+- **当** 某车牌在所有账户响应中都未匹配到记录（即 plate_contexts 中无对应项）
+- **那么** 系统必须跳过该车牌的续办派发并记录 WARN 日志，不得使用其他车牌的上下文回退
+
+#### 场景:同车牌出现在多账户时使用最新记录所在账户
+- **当** 车牌 A 同时出现在账户 1 和账户 2 的 stateList 响应中
+- **那么** 系统必须以 `apply_time` 最新的记录来源账户作为续办上下文，禁止使用首个匹配账户与最新记录混用
+
+#### 场景:同车牌同时存在六环内/六环外记录时仅取六环外作为续办上下文
+- **当** 车牌同时有六环内和六环外的进京证记录，且六环内的 apply_time 更新
+- **那么** 系统必须在续办上下文 plate_contexts 中仅记录该车牌六环外记录中 apply_time 最新的一条；推送链路（results[plate]）仍可使用所有类型中最新的记录显示
+
+### 需求:全局错峰串行执行
+系统必须使用全局 `threading.Lock()` 串行执行（兼容跨事件循环/线程的 cron 与 REST API 触发），保证任意时刻最多只有一条续办 API 调用链在执行，以实现多车牌之间的错峰。
+
+#### 场景:多车牌并发触发
+- **当** 同一次 push_workflow 内有多辆车牌命中续办决策
+- **那么** 系统必须在每条续办协程内通过全局 `threading.Lock()`（配合 `asyncio.to_thread` 抢锁）串行执行 `execute_renew`，前一条 API 链结束后才允许下一条进入
+
+#### 场景:信号量等待不设超时
+- **当** 多条续办协程同时争抢全局锁
+- **那么** 系统必须按醒来顺序排队，不得为锁获取设置超时时间，以避免因排队过久误判失败
+
+## 修改需求
+
+### 需求:续办触发判断
+系统必须在每次提醒（remind）查询完成后，对每个启用了自动续办的车牌调用决策器进行分场景判断，并按返回的 `RenewDecision` 派发后续动作。决策必须基于 `jjz_status.valid_end`、`sfyecbzxx`、`elzsfkb` 三个字段，覆盖以下五种结果：`SKIP` / `RENEW_TODAY` / `RENEW_TOMORROW` / `PENDING` / `NOT_AVAILABLE`。优先级为 `PENDING > NOT_AVAILABLE > RENEW_* > SKIP`。
+
+#### 场景:今日有效且明日有效
+- **当** `valid_start <= today` 且 `tomorrow <= valid_end`，且 `sfyecbzxx=False`，且 `elzsfkb=True`
+- **那么** 决策器必须返回 `SKIP`，系统不得派发续办
+
+#### 场景:今日有效但明日无效（场景①）
+- **当** `valid_start <= today <= valid_end` 且 `tomorrow > valid_end`，且 `sfyecbzxx=False`，且 `elzsfkb=True`
+- **那么** 决策器必须返回 `RENEW_TOMORROW`，系统必须派发续办流程，目标是续办明日的进京证
+
+#### 场景:今日已过期（场景②）
+- **当** `valid_end < today` 或 `status=EXPIRED`，且 `sfyecbzxx=False`，且 `elzsfkb=True`
+- **那么** 决策器必须返回 `RENEW_TODAY`，系统必须派发续办流程，目标是续办今日的进京证
+
+#### 场景:状态INVALID且无有效期跳过
+- **当** `status=INVALID` 且 `valid_end` 为空（无法解析有效期）
+- **那么** 决策器必须返回 `SKIP`，因为缺乏续办所需的 vId/有效期上下文，旧 should_renew 行为亦如此；用户已确认"无续办上下文"边缘 case 不处理
+
+#### 场景:已有待审记录
+- **当** 车辆 `sfyecbzxx=True`
+- **那么** 决策器必须返回 `PENDING`（无论 valid_end 状态），系统不得派发续办
+
+#### 场景:六环外不可办理
+- **当** `elzsfkb=False`
+- **那么** 决策器必须返回 `NOT_AVAILABLE`，系统不得派发续办，但必须推送"六环外进京证当前不可办理"告警
+
+#### 场景:非六环外记录跳过
+- **当** jjz_status.jjzzlmc 不包含"六环外"或为空
+- **那么** 决策器必须返回 `SKIP`，因为续办流程固定 `jjzzl="02"` 仅支持六环外续办
+
+#### 场景:auto_renew未启用
+- **当** 车牌的 `auto_renew` 配置为 `None` 或 `enabled=False`
+- **那么** 决策器必须返回 `SKIP`，系统不得派发续办
+
+### 需求:续办随机时间调度
+系统必须在续办派发时为每条协程生成 `[min_delay_seconds, max_delay_seconds]` 区间内的随机延迟（默认 30–180 秒），用于拟人化反爬。延迟期间不得占用全局信号量，sleep 醒来后才抢占信号量并执行 API 链。
+
+#### 场景:派发后随机延迟
+- **当** 决策命中 `RENEW_TODAY` 或 `RENEW_TOMORROW`，系统通过 `asyncio.create_task` 派发续办协程
+- **那么** 协程必须先 `await asyncio.sleep(random.randint(min_delay_seconds, max_delay_seconds))`，再尝试获取信号量
+
+#### 场景:使用默认延迟范围
+- **当** 用户未配置 `global.auto_renew.min_delay_seconds` 与 `max_delay_seconds`
+- **那么** 系统必须使用默认值 30 秒（min）与 180 秒（max）
+
+### 需求:防重复提交
+系统必须防止同一车牌在同一天内重复提交续办申请。当续办成功提交后写入 Redis 当日防重 key（TTL 24 小时）；当续办失败（包括 `checkHandle` 返回空 `jjrqs`）时不得写入防重 key，以便下一个 remind 时刻自然重试。
+
+#### 场景:当日已成功提交过续办
+- **当** 系统在 Redis 中检测到该车牌当日已有续办成功记录
+- **那么** 系统必须跳过续办，记录日志说明"当日已提交续办，跳过"
+
+#### 场景:成功提交后写入防重key
+- **当** `insertApplyRecord` 返回 `code==200`
+- **那么** 系统必须在 Redis 中写入 `auto_renew:{plate}:{today}` 记录，TTL 86400 秒
+
+#### 场景:失败时不写防重key允许重试
+- **当** 续办流程在任何步骤失败（包括 `checkHandle` 返回空 `jjrqs` 数组、Token 失效、API 报错）
+- **那么** 系统禁止写入当日防重 key，下一个 remind 时刻 push_workflow 必须重新决策并允许再次派发

--- a/openspec/changes/auto-renew-event-driven/specs/renew-config/spec.md
+++ b/openspec/changes/auto-renew-event-driven/specs/renew-config/spec.md
@@ -1,0 +1,27 @@
+## 新增需求
+
+### 需求:全局续办延迟配置
+系统必须支持在 `global.auto_renew` 中配置续办派发的随机延迟范围。`min_delay_seconds` 与 `max_delay_seconds` 均为整数（单位：秒），未配置时必须使用默认值 30 与 180。配置必须满足 `min_delay_seconds >= 0` 且 `min_delay_seconds <= max_delay_seconds`。
+
+#### 场景:自定义延迟范围
+- **当** 用户配置 `global.auto_renew.min_delay_seconds: 60` 与 `max_delay_seconds: 300`
+- **那么** 系统必须在每条续办协程派发后，于 60 至 300 秒之间随机选择一个延迟值进行 `asyncio.sleep`
+
+#### 场景:使用默认延迟范围
+- **当** `global.auto_renew` 未配置 `min_delay_seconds` 与 `max_delay_seconds`
+- **那么** 系统必须使用默认值 `min_delay_seconds=30`、`max_delay_seconds=180`
+
+#### 场景:无效延迟范围
+- **当** `min_delay_seconds < 0` 或 `min_delay_seconds > max_delay_seconds`
+- **那么** 系统必须在配置校验阶段报错，提示"续办延迟最小值必须 >= 0 且不大于最大值"
+
+#### 场景:检测到已废弃字段
+- **当** 用户配置文件中仍存在 `time_window_start` 或 `time_window_end` 字段
+- **那么** 系统必须在配置加载阶段输出 WARN 级日志，提示这些字段已废弃将被忽略，不得阻塞启动
+
+## 移除需求
+
+### 需求:全局续办时间窗口配置
+**Reason**: 触发模型从"凌晨 cron 窗口"改为"事件驱动 + 拟人化延迟"，时间窗口语义不再适用。
+
+**Migration**: 用户应将 `global.auto_renew.time_window_start` 与 `time_window_end` 从配置文件中移除。如需控制反爬延迟范围，改用新增的 `min_delay_seconds`（默认 30 秒）与 `max_delay_seconds`（默认 180 秒）。系统在加载到旧字段时会输出 WARN 日志但不阻塞启动。

--- a/openspec/changes/auto-renew-event-driven/tasks.md
+++ b/openspec/changes/auto-renew-event-driven/tasks.md
@@ -1,0 +1,59 @@
+## 1. 配置层改造
+
+- [x] 1.1 修改 `jjz_alert/config/config_models.py` 中 `GlobalAutoRenewConfig`：删除 `time_window_start` / `time_window_end`；新增 `min_delay_seconds: int = 30` 与 `max_delay_seconds: int = 180`
+- [x] 1.2 修改 `jjz_alert/config/config.py` 加载逻辑：读取新字段；检测到旧字段时输出 WARN 日志（"已废弃，将被忽略"）并跳过赋值
+- [x] 1.3 修改 `jjz_alert/config/validation.py`：删除 `_validate_auto_renew_time_window`；新增 `_validate_auto_renew_delay`（校验 `min >= 0` 且 `min <= max`）
+- [x] 1.4 更新 `config.yaml.example`：移除 `time_window_*` 注释/示例，新增 `min_delay_seconds` / `max_delay_seconds` 注释/示例
+
+## 2. 决策器实现
+
+- [x] 2.1 新建 `jjz_alert/service/jjz/renew_decider.py`：定义 `RenewDecision(Enum)`（`SKIP` / `RENEW_TODAY` / `RENEW_TOMORROW` / `PENDING` / `NOT_AVAILABLE`）
+- [x] 2.2 在同文件实现 `decide(plate_config: PlateConfig, jjz_status: JJZStatus) -> RenewDecision`，按优先级 `PENDING > NOT_AVAILABLE > RENEW_* > SKIP` 实现决策矩阵
+- [x] 2.3 新建 `tests/test_renew_decider.py`，覆盖所有决策分支：今日有效+明日有效、今日有效+明日到期、今日已过期、`status=INVALID`、`sfyecbzxx=True`、`elzsfkb=False`、`auto_renew.enabled=False`、`auto_renew=None`
+
+## 3. 派发器实现
+
+- [x] 3.1 新建 `jjz_alert/service/jjz/renew_trigger.py`：模块级 `RENEW_GLOBAL_SEMAPHORE = asyncio.Semaphore(1)`
+- [x] 3.2 在同文件实现 `async def schedule_renew(plate_config, jjz_status, response_data, accounts, decision, min_delay, max_delay)`：
+  - random.randint(min_delay, max_delay) → asyncio.sleep
+  - async with RENEW_GLOBAL_SEMAPHORE
+  - 检查 Redis 当日防重 key，已存在则跳过并记录日志
+  - 调用 `auto_renew_service.execute_renew(...)`
+  - 调用 `auto_renew_service.push_renew_result(...)` 推送结果
+- [x] 3.3 在 `tests/test_auto_renew.py` 新增 `schedule_renew` 集成测试：mock `asyncio.sleep` 和 `execute_renew`，验证信号量在多协程并发时串行执行
+
+## 4. push_workflow 接入
+
+- [x] 4.1 修改 `JJZService.get_multiple_status_optimized()` 或新增配套方法，使调用方能拿到原始 `response_data` 与 `accounts`（最简实现：返回元组或额外字段）
+- [x] 4.2 修改 `jjz_alert/service/notification/jjz_push_service.py` 的 `process_single_plate`：
+  - 在拿到 `jjz_status` 后调用 `decide(plate_config, jjz_status)`
+  - 决策为 `RENEW_TODAY` / `RENEW_TOMORROW` 时：`asyncio.create_task(schedule_renew(...))`，并把 `push_result` 设为 `{"success": True, "skipped": "renew_dispatched"}`，跳过原有 `push_jjz_reminder` 调用
+  - 决策为 `NOT_AVAILABLE` 时：保留现有"六环外不可办"告警逻辑（如果还没有，参照 `auto_renew_service.run_auto_renew_check` 中的告警代码迁移过来）
+  - 决策为 `PENDING` / `SKIP` 时：走原有正常推送分支
+- [x] 4.3 在 `process_single_plate` 内通过 `app_config.global_config.auto_renew` 读取 `min_delay_seconds` / `max_delay_seconds` 并传给 `schedule_renew`
+
+## 5. 删除遗留代码
+
+- [x] 5.1 删除 `jjz_alert/service/jjz/auto_renew_service.py` 中的 `run_auto_renew_check()` 函数及其全部依赖
+- [x] 5.2 删除 `auto_renew_service.py` 中的 `should_renew()` 函数（被 `decide` 替代）
+- [x] 5.3 删除 `auto_renew_service.py` 中的 `calculate_random_delay()` 静态方法
+- [x] 5.4 修改 `main.py`：删除自动续办 cron 注册分支（`if renew_plates:` 块及 `async_renew_wrapper`）
+- [x] 5.5 修改 `main.py`：调整 `has_auto_renew` 启动判断——当只有 auto_renew 启用、无 remind 时，不再单独启动 cron；保留对"无 remind 且无 auto_renew"时执行一次 `main()` 的兜底
+- [x] 5.6 删除 `tests/test_auto_renew.py` 中针对 `should_renew` / `run_auto_renew_check` / `calculate_random_delay` 的测试用例
+- [x] 5.7 全局搜索 `time_window_start` / `time_window_end` / `run_auto_renew_check` / `should_renew` 的残留引用，确认无悬挂
+
+## 6. 测试与验证
+
+- [x] 6.1 运行 `pytest tests/test_renew_decider.py` 全绿
+- [x] 6.2 运行 `pytest tests/test_auto_renew.py` 全绿
+- [x] 6.3 运行 `pytest tests/test_config.py`（如存在）覆盖新配置字段
+- [x] 6.4 运行完整 `pytest` 确认无回归
+- [x] 6.5 本地用真实/mock 配置启动 main.py，观察日志是否输出："已添加自动续办派发"或"决策器命中 RENEW_*"等结构化日志
+- [x] 6.6 用伪造的 stateList 响应触发 push_workflow，验证场景①（明日缺）与场景②（今日缺）都能派发并完成 mock 续办，并观察通知抑制行为正确
+- [x] 6.7 验证旧字段（`time_window_start`）写在 yaml 中时启动会输出 WARN 但不挂
+
+## 7. 文档与归档
+
+- [x] 7.1 更新 README.md（如有提及自动续办触发机制的章节）— README 未涉及，无需修改
+- [x] 7.2 运行 `openspec-cn validate auto-renew-event-driven` 确认提案结构合法
+- [ ] 7.3 完成实施后调用 `/opsx:archive` 归档变更

--- a/tests/unit/app/test_main.py
+++ b/tests/unit/app/test_main.py
@@ -2,10 +2,11 @@ import logging
 import sys
 from dataclasses import dataclass
 from types import ModuleType
+from unittest.mock import MagicMock
 
 import pytest
 
-from main import main as run_main
+from main import main as run_main, schedule_jobs
 
 
 @dataclass
@@ -81,3 +82,128 @@ async def test_main_logs_ha_sync_failure(monkeypatch, caplog):
 
     ha_messages = [record.message for record in caplog.records]
     assert any("Home Assistant同步失败" in msg for msg in ha_messages)
+
+
+# ---------- schedule_jobs 凌晨兜底 cron 注册行为测试 ----------
+
+
+def _build_app_config(remind_enable, remind_times, auto_renew_enabled):
+    """构造测试用 AppConfig，覆盖 remind 与 auto_renew 各种组合"""
+    from jjz_alert.config.config_models import (
+        AppConfig,
+        AutoRenewConfig,
+        GlobalConfig,
+        PlateConfig,
+        RemindConfig,
+    )
+
+    remind = RemindConfig(enable=remind_enable, times=list(remind_times))
+    global_config = GlobalConfig(remind=remind)
+    auto_renew = (
+        AutoRenewConfig(enabled=True, purpose="test")
+        if auto_renew_enabled
+        else None
+    )
+    plate = PlateConfig(plate="京A12345", auto_renew=auto_renew)
+    return AppConfig(global_config=global_config, plates=[plate])
+
+
+def _patch_schedule_jobs(monkeypatch, app_config):
+    """注入 schedule_jobs 所需的桩对象，返回收集到的 add_job 调用列表"""
+    # main.schedule_jobs 内通过 `from jjz_alert.config.config import config_manager`
+    # 延迟导入，因此需直接 patch 源模块上的属性
+    from jjz_alert.config import config as _cfg_module
+
+    fake_cm = MagicMock()
+    fake_cm.load_config.return_value = app_config
+    monkeypatch.setattr(_cfg_module, "config_manager", fake_cm)
+
+    add_job_calls = []
+
+    class FakeScheduler:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def add_job(self, func, trigger, **kwargs):
+            add_job_calls.append({"trigger": trigger, "kwargs": kwargs})
+
+        def start(self):
+            # 测试中不真正阻塞
+            return None
+
+    monkeypatch.setattr("main.BlockingScheduler", FakeScheduler)
+    # 屏蔽信号注册（避免在非主线程下抛出 ValueError）
+    monkeypatch.setattr("main.signal.signal", lambda *a, **kw: None)
+    return add_job_calls
+
+
+def _has_midnight_fallback(add_job_calls):
+    """判断是否注册了 00:30 兜底 cron"""
+    for call in add_job_calls:
+        trigger = call["trigger"]
+        fields = {f.name: str(f) for f in trigger.fields}
+        if fields.get("hour") == "0" and fields.get("minute") == "30":
+            return True
+    return False
+
+
+def test_midnight_fallback_when_remind_disabled(monkeypatch):
+    """remind 关闭 + auto_renew 开启 -> 注册 00:30 兜底"""
+    app_config = _build_app_config(
+        remind_enable=False, remind_times=[], auto_renew_enabled=True
+    )
+    add_job_calls = _patch_schedule_jobs(monkeypatch, app_config)
+    schedule_jobs()
+    assert _has_midnight_fallback(add_job_calls)
+
+
+def test_midnight_fallback_when_remind_lacks_post_midnight(monkeypatch):
+    """remind 开启但无凌晨时刻 + auto_renew 开启 -> 注册 00:30 兜底"""
+    app_config = _build_app_config(
+        remind_enable=True,
+        remind_times=["07:00", "23:55"],
+        auto_renew_enabled=True,
+    )
+    add_job_calls = _patch_schedule_jobs(monkeypatch, app_config)
+    schedule_jobs()
+    assert _has_midnight_fallback(add_job_calls)
+
+
+def test_no_fallback_when_remind_has_post_midnight(monkeypatch):
+    """remind 已含凌晨时刻 (00:30) + auto_renew 开启 -> 不重复注册兜底"""
+    app_config = _build_app_config(
+        remind_enable=True,
+        remind_times=["00:30", "12:00"],
+        auto_renew_enabled=True,
+    )
+    add_job_calls = _patch_schedule_jobs(monkeypatch, app_config)
+    schedule_jobs()
+    # 应只注册 remind cron 中已存在的 00:30，而非额外的兜底任务
+    midnight_jobs = [
+        c
+        for c in add_job_calls
+        if {f.name: str(f) for f in c["trigger"].fields}.get("hour") == "0"
+        and {f.name: str(f) for f in c["trigger"].fields}.get("minute") == "30"
+    ]
+    assert len(midnight_jobs) == 1
+
+
+def test_no_fallback_when_no_auto_renew(monkeypatch):
+    """auto_renew 关闭 -> 无论 remind 状态都不注册兜底"""
+    # remind 关闭场景
+    app_config = _build_app_config(
+        remind_enable=False, remind_times=[], auto_renew_enabled=False
+    )
+    add_job_calls = _patch_schedule_jobs(monkeypatch, app_config)
+    schedule_jobs()
+    assert not _has_midnight_fallback(add_job_calls)
+
+    # remind 开启且 times 不含凌晨场景
+    app_config2 = _build_app_config(
+        remind_enable=True,
+        remind_times=["07:00", "23:55"],
+        auto_renew_enabled=False,
+    )
+    add_job_calls2 = _patch_schedule_jobs(monkeypatch, app_config2)
+    schedule_jobs()
+    assert not _has_midnight_fallback(add_job_calls2)

--- a/tests/unit/app/test_main.py
+++ b/tests/unit/app/test_main.py
@@ -100,9 +100,7 @@ def _build_app_config(remind_enable, remind_times, auto_renew_enabled):
     remind = RemindConfig(enable=remind_enable, times=list(remind_times))
     global_config = GlobalConfig(remind=remind)
     auto_renew = (
-        AutoRenewConfig(enabled=True, purpose="test")
-        if auto_renew_enabled
-        else None
+        AutoRenewConfig(enabled=True, purpose="test") if auto_renew_enabled else None
     )
     plate = PlateConfig(plate="京A12345", auto_renew=auto_renew)
     return AppConfig(global_config=global_config, plates=[plate])

--- a/tests/unit/config/test_auto_renew_config.py
+++ b/tests/unit/config/test_auto_renew_config.py
@@ -29,8 +29,8 @@ class TestAutoRenewConfigParsing:
             "global": {
                 "redis": {"host": "localhost"},
                 "auto_renew": {
-                    "time_window_start": "01:00",
-                    "time_window_end": "05:00",
+                    "min_delay_seconds": 60,
+                    "max_delay_seconds": 240,
                 },
             },
             "plates": [
@@ -69,8 +69,8 @@ class TestAutoRenewConfigParsing:
         config = manager.load_config()
 
         # 全局配置
-        assert config.global_config.auto_renew.time_window_start == "01:00"
-        assert config.global_config.auto_renew.time_window_end == "05:00"
+        assert config.global_config.auto_renew.min_delay_seconds == 60
+        assert config.global_config.auto_renew.max_delay_seconds == 240
 
         # 车牌配置
         plate = config.plates[0]
@@ -104,8 +104,61 @@ class TestAutoRenewConfigParsing:
         manager = ConfigManager(str(config_file))
         config = manager.load_config()
 
-        assert config.global_config.auto_renew.time_window_start == "00:00"
-        assert config.global_config.auto_renew.time_window_end == "06:00"
+        assert config.global_config.auto_renew.min_delay_seconds == 30
+        assert config.global_config.auto_renew.max_delay_seconds == 180
+
+    def test_legacy_time_window_fields_warn_and_use_defaults(self, tmp_path, caplog):
+        """旧 time_window_* 字段保留时输出 WARN 但不阻塞，使用新字段默认值"""
+        import logging as _logging
+
+        config_data = {
+            "global": {
+                "redis": {"host": "localhost"},
+                "auto_renew": {
+                    "time_window_start": "00:00",
+                    "time_window_end": "06:00",
+                },
+            }
+        }
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(yaml.dump(config_data), encoding="utf-8")
+
+        manager = ConfigManager(str(config_file))
+        with caplog.at_level(_logging.WARNING):
+            config = manager.load_config()
+
+        assert config.global_config.auto_renew.min_delay_seconds == 30
+        assert config.global_config.auto_renew.max_delay_seconds == 180
+        assert any("time_window_start" in r.message for r in caplog.records)
+
+    def test_invalid_delay_value_falls_back_to_default(self, tmp_path, caplog):
+        """min_delay_seconds 配为非数字时输出 WARN 并使用默认，且不丢失其他配置"""
+        import logging as _logging
+
+        config_data = {
+            "global": {
+                "redis": {"host": "localhost"},
+                "auto_renew": {"min_delay_seconds": "not-a-number"},
+            },
+            "jjz_accounts": [
+                {"name": "测试账户", "jjz": {"token": "t", "url": "https://x/pro/a"}}
+            ],
+            "plates": [{"plate": "京A12345", "notifications": []}],
+        }
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(yaml.dump(config_data), encoding="utf-8")
+
+        manager = ConfigManager(str(config_file))
+        with caplog.at_level(_logging.WARNING):
+            config = manager.load_config()
+
+        # 异常字段使用默认值
+        assert config.global_config.auto_renew.min_delay_seconds == 30
+        assert any("min_delay_seconds" in r.message for r in caplog.records)
+        # 其他配置未丢失
+        assert len(config.jjz_accounts) == 1
+        assert len(config.plates) == 1
+        assert config.plates[0].plate == "京A12345"
 
     def test_default_apply_location(self, tmp_path):
         """未配置 apply_location 时使用默认坐标（非 destination 坐标）"""
@@ -209,22 +262,32 @@ class TestAutoRenewConfigValidation:
         ]
         assert validator.validate(config) is True
 
-    def test_invalid_time_window(self):
-        """无效时间窗口报错"""
+    def test_invalid_delay_range(self):
+        """min > max 报错"""
         validator = ConfigValidator()
         config = AppConfig()
         config.global_config.auto_renew = GlobalAutoRenewConfig(
-            time_window_start="06:00", time_window_end="01:00"
+            min_delay_seconds=300, max_delay_seconds=60
         )
         validator.validate(config)
-        assert any("起始时间必须早于结束时间" in e for e in validator.errors)
+        assert any("min_delay_seconds" in e for e in validator.errors)
 
-    def test_valid_time_window(self):
-        """合法时间窗口通过"""
+    def test_negative_delay(self):
+        """负数延迟报错"""
         validator = ConfigValidator()
         config = AppConfig()
         config.global_config.auto_renew = GlobalAutoRenewConfig(
-            time_window_start="01:00", time_window_end="05:00"
+            min_delay_seconds=-1, max_delay_seconds=180
         )
-        result = validator.validate(config)
-        assert not any("时间窗口" in e for e in validator.errors)
+        validator.validate(config)
+        assert any("min_delay_seconds" in e for e in validator.errors)
+
+    def test_valid_delay_range(self):
+        """合法延迟范围通过"""
+        validator = ConfigValidator()
+        config = AppConfig()
+        config.global_config.auto_renew = GlobalAutoRenewConfig(
+            min_delay_seconds=30, max_delay_seconds=180
+        )
+        validator.validate(config)
+        assert not any("delay" in e.lower() for e in validator.errors)

--- a/tests/unit/service/test_auto_renew.py
+++ b/tests/unit/service/test_auto_renew.py
@@ -2,8 +2,9 @@
 自动续办服务单元测试
 """
 
-from datetime import date, datetime, timedelta
-from unittest.mock import AsyncMock, MagicMock, patch, PropertyMock
+import asyncio
+from datetime import date, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -17,6 +18,7 @@ from jjz_alert.config.config_models import (
 from jjz_alert.service.jjz.auto_renew_service import AutoRenewService, RenewResult
 from jjz_alert.service.jjz.jjz_status import JJZStatus
 from jjz_alert.service.jjz.jjz_status_enum import JJZStatusEnum
+from jjz_alert.service.jjz.renew_decider import RenewDecision
 
 
 def _make_ar_config(**overrides):
@@ -67,71 +69,6 @@ def _make_jjz_status(plate="京A12345", **overrides):
 
 
 @pytest.mark.unit
-class TestShouldRenew:
-    """续办触发判断测试"""
-
-    def setup_method(self):
-        self.service = AutoRenewService()
-
-    def test_permit_expires_tomorrow(self):
-        """证件明天到期 → 应触发续办"""
-        tomorrow = (date.today() + timedelta(days=1)).isoformat()
-        pc = _make_plate_config()
-        status = _make_jjz_status(valid_end=tomorrow)
-        assert self.service.should_renew(pc, status) is True
-
-    def test_permit_already_expired(self):
-        """证件已过期 → 应触发续办"""
-        yesterday = (date.today() - timedelta(days=1)).isoformat()
-        pc = _make_plate_config()
-        status = _make_jjz_status(
-            valid_end=yesterday, status=JJZStatusEnum.EXPIRED.value
-        )
-        assert self.service.should_renew(pc, status) is True
-
-    def test_permit_has_pending_record(self):
-        """已有待审记录 → 不续办"""
-        tomorrow = (date.today() + timedelta(days=1)).isoformat()
-        pc = _make_plate_config()
-        status = _make_jjz_status(valid_end=tomorrow, sfyecbzxx=True)
-        assert self.service.should_renew(pc, status) is False
-
-    def test_outer_not_available_still_returns_true(self):
-        """六环外不可办理 → should_renew 仍返回 True（由调用方处理通知）"""
-        tomorrow = (date.today() + timedelta(days=1)).isoformat()
-        pc = _make_plate_config()
-        status = _make_jjz_status(valid_end=tomorrow, elzsfkb=False)
-        assert self.service.should_renew(pc, status) is True
-
-    def test_permit_still_valid(self):
-        """有效期充足（>1天）→ 不续办"""
-        future = (date.today() + timedelta(days=5)).isoformat()
-        pc = _make_plate_config()
-        status = _make_jjz_status(valid_end=future, days_remaining=5)
-        assert self.service.should_renew(pc, status) is False
-
-    def test_auto_renew_disabled(self):
-        """续办未启用 → 不续办"""
-        ar = _make_ar_config(enabled=False)
-        pc = _make_plate_config(ar_config=ar)
-        status = _make_jjz_status()
-        assert self.service.should_renew(pc, status) is False
-
-    def test_no_auto_renew_config(self):
-        """无续办配置 → 不续办"""
-        pc = PlateConfig(plate="京A12345")
-        status = _make_jjz_status()
-        assert self.service.should_renew(pc, status) is False
-
-    def test_inner_ring_permit_skipped(self):
-        """六环内进京证 → 不续办"""
-        tomorrow = (date.today() + timedelta(days=1)).isoformat()
-        pc = _make_plate_config()
-        status = _make_jjz_status(valid_end=tomorrow, jjzzlmc="进京证（六环内）")
-        assert self.service.should_renew(pc, status) is False
-
-
-@pytest.mark.unit
 class TestBuildApplyRequest:
     """请求体组装测试"""
 
@@ -155,31 +92,20 @@ class TestBuildApplyRequest:
             status, ar, driver_info, "2026-04-01", metadata
         )
 
-        # stateList 字段
         assert body["vId"] == "V001"
         assert body["hphm"] == "京A12345"
         assert body["hpzl"] == "02"
         assert body["cllx"] == "01"
         assert body["elzqyms"] == "六环外规则"
-
-        # 驾驶人信息
         assert body["jsrxm"] == "张三"
         assert body["jszh"] == "110101199001011234"
-
-        # 进京日期
         assert body["jjrq"] == "2026-04-01"
-
-        # 固定值
         assert body["jjzzl"] == "02"
         assert body["txrxx"] == []
         assert body["jingState"] == ""
-
-        # 用户配置
         assert body["area"] == "朝阳区"
         assert body["jjmd"] == "03"
         assert body["jjmdmc"] == "探亲访友"
-
-        # 住宿
         assert body["sfzj"] == "1"
         assert body["zjxxdz"] == "住宿地址"
 
@@ -195,34 +121,6 @@ class TestBuildApplyRequest:
         )
         assert body["sfzj"] == "0"
         assert body["zjxxdz"] == ""
-
-
-@pytest.mark.unit
-class TestCalculateRandomDelay:
-    """随机延迟计算测试"""
-
-    @patch("jjz_alert.service.jjz.auto_renew_service.datetime")
-    def test_default_window(self, mock_dt):
-        """mock 到 00:30，窗口 00:00-06:00 → 延迟在 0~19800 之间"""
-        mock_dt.now.return_value = datetime(2026, 3, 29, 0, 30, 0)
-        delay = AutoRenewService.calculate_random_delay("00:00", "06:00")
-        # 00:30 到 06:00 = 5.5h = 19800s
-        assert 0 <= delay <= 19800
-
-    @patch("jjz_alert.service.jjz.auto_renew_service.datetime")
-    def test_custom_window(self, mock_dt):
-        """mock 到 00:00，窗口 01:00-02:00 → 延迟含到窗口起始的偏移"""
-        mock_dt.now.return_value = datetime(2026, 3, 29, 0, 0, 0)
-        delay = AutoRenewService.calculate_random_delay("01:00", "02:00")
-        # 从 00:00 到 01:00-02:00 之间的随机时刻，延迟在 3600~7200 之间
-        assert 3600 <= delay <= 7200
-
-    @patch("jjz_alert.service.jjz.auto_renew_service.datetime")
-    def test_negative_delay_when_past_window(self, mock_dt):
-        """窗口已过 → 返回 -1 表示不应执行"""
-        mock_dt.now.return_value = datetime(2026, 3, 29, 7, 0, 0)
-        delay = AutoRenewService.calculate_random_delay("00:00", "06:00")
-        assert delay == -1
 
 
 @pytest.mark.unit
@@ -314,3 +212,133 @@ class TestApiCallChain:
             self.service._vehicle_check("http://test", "token", "京A12345", "02")
             is False
         )
+
+
+@pytest.mark.unit
+class TestScheduleRenew:
+    """续办派发器集成测试（mock sleep + execute_renew）"""
+
+    @pytest.mark.asyncio
+    async def test_dispatch_runs_execute_and_push(self):
+        from jjz_alert.service.jjz import renew_trigger
+
+        plate_config = _make_plate_config()
+        jjz_status = _make_jjz_status()
+        response_data = {"data": {}}
+
+        with patch(
+            "jjz_alert.service.jjz.renew_trigger._has_renewed_today",
+            new=AsyncMock(return_value=False),
+        ), patch(
+            "jjz_alert.service.jjz.renew_trigger.asyncio.sleep",
+            new=AsyncMock(return_value=None),
+        ), patch(
+            "jjz_alert.service.jjz.renew_trigger.auto_renew_service"
+        ) as mock_service:
+            mock_service.execute_renew = AsyncMock(
+                return_value=RenewResult(
+                    plate=plate_config.plate,
+                    success=True,
+                    message="ok",
+                    step="done",
+                    jjrq="2026-04-01",
+                )
+            )
+            mock_service.push_renew_result = AsyncMock(return_value=None)
+
+            await renew_trigger.schedule_renew(
+                plate_config,
+                jjz_status,
+                response_data,
+                accounts=None,
+                decision=RenewDecision.RENEW_TOMORROW,
+                min_delay=0,
+                max_delay=0,
+            )
+
+            mock_service.execute_renew.assert_awaited_once()
+            mock_service.push_renew_result.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_dedup_skips_execute(self):
+        from jjz_alert.service.jjz import renew_trigger
+
+        plate_config = _make_plate_config()
+        jjz_status = _make_jjz_status()
+
+        with patch(
+            "jjz_alert.service.jjz.renew_trigger._has_renewed_today",
+            new=AsyncMock(return_value=True),
+        ), patch(
+            "jjz_alert.service.jjz.renew_trigger.asyncio.sleep",
+            new=AsyncMock(return_value=None),
+        ), patch(
+            "jjz_alert.service.jjz.renew_trigger.auto_renew_service"
+        ) as mock_service:
+            mock_service.execute_renew = AsyncMock()
+            mock_service.push_renew_result = AsyncMock()
+
+            await renew_trigger.schedule_renew(
+                plate_config,
+                jjz_status,
+                {"data": {}},
+                accounts=None,
+                decision=RenewDecision.RENEW_TODAY,
+                min_delay=0,
+                max_delay=0,
+            )
+
+            mock_service.execute_renew.assert_not_called()
+            mock_service.push_renew_result.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_global_lock_serializes_concurrent_dispatches(self):
+        """多协程并发时通过全局锁串行执行（threading.Lock 跨 loop/线程安全）"""
+        from jjz_alert.service.jjz import renew_trigger
+
+        running = 0
+        max_concurrent = 0
+        order = []
+
+        async def fake_execute_renew(plate_config, *args, **kwargs):
+            nonlocal running, max_concurrent
+            running += 1
+            max_concurrent = max(max_concurrent, running)
+            order.append(plate_config.plate)
+            await asyncio.sleep(0)
+            running -= 1
+            return RenewResult(
+                plate=plate_config.plate,
+                success=True,
+                message="ok",
+                step="done",
+            )
+
+        with patch(
+            "jjz_alert.service.jjz.renew_trigger._has_renewed_today",
+            new=AsyncMock(return_value=False),
+        ), patch(
+            "jjz_alert.service.jjz.renew_trigger.asyncio.sleep",
+            new=AsyncMock(return_value=None),
+        ), patch(
+            "jjz_alert.service.jjz.renew_trigger.auto_renew_service"
+        ) as mock_service:
+            mock_service.execute_renew = AsyncMock(side_effect=fake_execute_renew)
+            mock_service.push_renew_result = AsyncMock(return_value=None)
+
+            tasks = [
+                renew_trigger.schedule_renew(
+                    _make_plate_config(plate=f"京A0000{i}"),
+                    _make_jjz_status(plate=f"京A0000{i}"),
+                    {"data": {}},
+                    accounts=None,
+                    decision=RenewDecision.RENEW_TODAY,
+                    min_delay=0,
+                    max_delay=0,
+                )
+                for i in range(4)
+            ]
+            await asyncio.gather(*tasks)
+
+        assert max_concurrent == 1
+        assert len(order) == 4

--- a/tests/unit/service/test_jjz_service.py
+++ b/tests/unit/service/test_jjz_service.py
@@ -922,6 +922,118 @@ class TestJJZService:
                     assert results["京A12345"].status == JJZStatusEnum.VALID.value
 
     @pytest.mark.asyncio
+    async def test_get_multiple_status_with_context_outer_only_for_renew(
+        self, jjz_service, sample_jjz_account
+    ):
+        """同车牌同时存在六环外（旧）与六环内（新）记录时，
+        plate_contexts 中的 renew_status 必须仅取六环外那条；
+        results[plate] 仍取所有记录中 apply_time 最新（六环内）的一条。
+        """
+        plates = ["京A12345"]
+
+        with patch.object(jjz_service, "load_accounts") as mock_load:
+            mock_load.return_value = [sample_jjz_account]
+
+            with patch.object(jjz_service, "check_jjz_status") as mock_check:
+                mock_check.return_value = {
+                    "data": {
+                        "bzclxx": [
+                            {
+                                "hphm": "京A12345",
+                                "sycs": "8",
+                                "bzxx": [
+                                    # 六环外，apply_time 较旧，valid_end 今日
+                                    {
+                                        "jjzzlmc": "进京证(六环外)",
+                                        "blztmc": "审核通过(生效中)",
+                                        "blzt": "1",
+                                        "sqsj": "2025-08-10 09:00:00",
+                                        "yxqs": "2025-08-10",
+                                        "yxqz": "2025-08-15",
+                                        "sxsyts": "0",
+                                    },
+                                    # 六环内，apply_time 较新，valid_end 远期
+                                    {
+                                        "jjzzlmc": "进京证(六环内)",
+                                        "blztmc": "审核通过(生效中)",
+                                        "blzt": "1",
+                                        "sqsj": "2025-08-15 09:00:00",
+                                        "yxqs": "2025-08-15",
+                                        "yxqz": "2025-08-20",
+                                        "sxsyts": "5",
+                                    },
+                                ],
+                            }
+                        ]
+                    }
+                }
+
+                with patch("jjz_alert.service.jjz.jjz_service.date") as mock_date:
+                    mock_date.today.return_value = date(2025, 8, 15)
+
+                    (
+                        results,
+                        plate_contexts,
+                    ) = await jjz_service.get_multiple_status_with_context(plates)
+
+                    # results 取最新的六环内记录用于推送/显示
+                    assert "京A12345" in results
+                    assert results["京A12345"].jjzzlmc == "进京证(六环内)"
+
+                    # plate_contexts 续办上下文必须仅取六环外
+                    assert "京A12345" in plate_contexts
+                    ctx = plate_contexts["京A12345"]
+                    assert len(ctx) == 3, "plate_contexts 必须为 (response, account, renew_status) 三元组"
+                    ctx_response, ctx_account, ctx_renew_status = ctx
+                    assert ctx_account is sample_jjz_account
+                    assert ctx_renew_status.jjzzlmc == "进京证(六环外)"
+                    assert ctx_renew_status.valid_end == "2025-08-15"
+
+    @pytest.mark.asyncio
+    async def test_get_multiple_status_with_context_no_outer(
+        self, jjz_service, sample_jjz_account
+    ):
+        """车牌仅有六环内记录时，plate_contexts 中不应写入该车牌。"""
+        plates = ["京A12345"]
+
+        with patch.object(jjz_service, "load_accounts") as mock_load:
+            mock_load.return_value = [sample_jjz_account]
+
+            with patch.object(jjz_service, "check_jjz_status") as mock_check:
+                mock_check.return_value = {
+                    "data": {
+                        "bzclxx": [
+                            {
+                                "hphm": "京A12345",
+                                "sycs": "8",
+                                "bzxx": [
+                                    {
+                                        "jjzzlmc": "进京证(六环内)",
+                                        "blztmc": "审核通过(生效中)",
+                                        "blzt": "1",
+                                        "sqsj": "2025-08-15 09:00:00",
+                                        "yxqs": "2025-08-15",
+                                        "yxqz": "2025-08-20",
+                                        "sxsyts": "5",
+                                    }
+                                ],
+                            }
+                        ]
+                    }
+                }
+
+                with patch("jjz_alert.service.jjz.jjz_service.date") as mock_date:
+                    mock_date.today.return_value = date(2025, 8, 15)
+
+                    (
+                        results,
+                        plate_contexts,
+                    ) = await jjz_service.get_multiple_status_with_context(plates)
+
+                    assert results["京A12345"].jjzzlmc == "进京证(六环内)"
+                    assert "京A12345" not in plate_contexts
+
+    @pytest.mark.asyncio
     async def test_fetch_from_api_exception(self, jjz_service, sample_jjz_account):
         """测试 _fetch_from_api - 异常处理"""
         plate = "京A12345"

--- a/tests/unit/service/test_jjz_service.py
+++ b/tests/unit/service/test_jjz_service.py
@@ -983,7 +983,9 @@ class TestJJZService:
                     # plate_contexts 续办上下文必须仅取六环外
                     assert "京A12345" in plate_contexts
                     ctx = plate_contexts["京A12345"]
-                    assert len(ctx) == 3, "plate_contexts 必须为 (response, account, renew_status) 三元组"
+                    assert (
+                        len(ctx) == 3
+                    ), "plate_contexts 必须为 (response, account, renew_status) 三元组"
                     ctx_response, ctx_account, ctx_renew_status = ctx
                     assert ctx_account is sample_jjz_account
                     assert ctx_renew_status.jjzzlmc == "进京证(六环外)"

--- a/tests/unit/service/test_renew_decider.py
+++ b/tests/unit/service/test_renew_decider.py
@@ -1,0 +1,130 @@
+"""
+续办决策器单元测试
+"""
+
+from datetime import date, timedelta
+
+import pytest
+
+from jjz_alert.config.config_models import (
+    AutoRenewConfig,
+    AutoRenewDestinationConfig,
+    PlateConfig,
+)
+from jjz_alert.service.jjz.jjz_status import JJZStatus
+from jjz_alert.service.jjz.jjz_status_enum import JJZStatusEnum
+from jjz_alert.service.jjz.renew_decider import RenewDecision, decide
+
+
+def _ar(enabled=True):
+    return AutoRenewConfig(
+        enabled=enabled,
+        purpose="03",
+        purpose_name="探亲访友",
+        destination=AutoRenewDestinationConfig(
+            area="朝阳区",
+            area_code="010",
+            address="测试地址",
+            lng="116.4",
+            lat="39.9",
+        ),
+    )
+
+
+def _plate(ar=None):
+    return PlateConfig(plate="京A12345", display_name="测试车", auto_renew=ar)
+
+
+def _status(**overrides):
+    today = date.today()
+    defaults = dict(
+        plate="京A12345",
+        status=JJZStatusEnum.VALID.value,
+        valid_start=(today - timedelta(days=2)).isoformat(),
+        valid_end=(today + timedelta(days=3)).isoformat(),
+        days_remaining=3,
+        jjzzlmc="进京证（六环外）",
+        vId="V001",
+        hpzl="02",
+        elzsfkb=True,
+        ylzsfkb=True,
+        cllx="01",
+        sfyecbzxx=False,
+        data_source="api",
+    )
+    defaults.update(overrides)
+    return JJZStatus(**defaults)
+
+
+@pytest.mark.unit
+class TestDecide:
+    def test_today_valid_tomorrow_valid_skip(self):
+        today = date.today()
+        s = _status(valid_end=(today + timedelta(days=3)).isoformat())
+        assert decide(_plate(_ar()), s) == RenewDecision.SKIP
+
+    def test_today_valid_tomorrow_invalid_renew_tomorrow(self):
+        today = date.today()
+        s = _status(valid_end=today.isoformat())
+        assert decide(_plate(_ar()), s) == RenewDecision.RENEW_TOMORROW
+
+    def test_today_expired_renew_today(self):
+        today = date.today()
+        s = _status(
+            valid_end=(today - timedelta(days=1)).isoformat(),
+            status=JJZStatusEnum.EXPIRED.value,
+        )
+        assert decide(_plate(_ar()), s) == RenewDecision.RENEW_TODAY
+
+    def test_status_invalid_skips(self):
+        """INVALID 缺少 vId 等续办字段，显式跳过避免无意义派发"""
+        s = _status(status=JJZStatusEnum.INVALID.value, valid_end=None)
+        assert decide(_plate(_ar()), s) == RenewDecision.SKIP
+
+    def test_pending_record_pending(self):
+        today = date.today()
+        s = _status(
+            valid_end=(today - timedelta(days=1)).isoformat(),
+            status=JJZStatusEnum.EXPIRED.value,
+            sfyecbzxx=True,
+        )
+        assert decide(_plate(_ar()), s) == RenewDecision.PENDING
+
+    def test_outer_not_available(self):
+        today = date.today()
+        s = _status(valid_end=today.isoformat(), elzsfkb=False)
+        assert decide(_plate(_ar()), s) == RenewDecision.NOT_AVAILABLE
+
+    def test_auto_renew_disabled(self):
+        s = _status()
+        assert decide(_plate(_ar(enabled=False)), s) == RenewDecision.SKIP
+
+    def test_no_auto_renew_config(self):
+        s = _status()
+        assert decide(_plate(None), s) == RenewDecision.SKIP
+
+    def test_inner_ring_permit_skipped(self):
+        s = _status(jjzzlmc="进京证（六环内）")
+        assert decide(_plate(_ar()), s) == RenewDecision.SKIP
+
+    def test_missing_jjzzlmc_skipped(self):
+        today = date.today()
+        s = _status(
+            jjzzlmc=None,
+            status=JJZStatusEnum.VALID.value,
+            valid_end=today.isoformat(),
+        )
+        assert decide(_plate(_ar()), s) == RenewDecision.SKIP
+
+    def test_pending_takes_priority_over_not_available(self):
+        today = date.today()
+        s = _status(
+            valid_end=today.isoformat(),
+            sfyecbzxx=True,
+            elzsfkb=False,
+        )
+        assert decide(_plate(_ar()), s) == RenewDecision.PENDING
+
+    def test_invalid_valid_end_format_skips(self):
+        s = _status(valid_end="not-a-date", status=JJZStatusEnum.VALID.value)
+        assert decide(_plate(_ar()), s) == RenewDecision.SKIP

--- a/tests/unit/service/test_renew_workflow.py
+++ b/tests/unit/service/test_renew_workflow.py
@@ -1,0 +1,140 @@
+"""
+仅续办工作流单元测试
+"""
+
+from datetime import date, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from jjz_alert.config.config_models import (
+    AppConfig,
+    AutoRenewConfig,
+    AutoRenewDestinationConfig,
+    GlobalAutoRenewConfig,
+    PlateConfig,
+)
+from jjz_alert.service.jjz.jjz_status import JJZStatus
+from jjz_alert.service.jjz.jjz_status_enum import JJZStatusEnum
+
+
+def _make_config_with_renew_plate():
+    config = AppConfig()
+    config.global_config.auto_renew = GlobalAutoRenewConfig(
+        min_delay_seconds=0, max_delay_seconds=0
+    )
+    config.plates = [
+        PlateConfig(
+            plate="京A12345",
+            auto_renew=AutoRenewConfig(
+                enabled=True,
+                purpose="03",
+                purpose_name="探亲访友",
+                destination=AutoRenewDestinationConfig(
+                    area="朝阳区",
+                    area_code="010",
+                    address="测试地址",
+                    lng="116.4",
+                    lat="39.9",
+                ),
+            ),
+        )
+    ]
+    return config
+
+
+def _make_renew_status(plate="京A12345", **overrides):
+    today = date.today()
+    defaults = dict(
+        plate=plate,
+        status=JJZStatusEnum.VALID.value,
+        valid_start=(today - timedelta(days=2)).isoformat(),
+        valid_end=today.isoformat(),
+        jjzzlmc="进京证（六环外）",
+        vId="V001",
+        hpzl="02",
+        elzsfkb=True,
+        sfyecbzxx=False,
+    )
+    defaults.update(overrides)
+    return JJZStatus(**defaults)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_run_renew_only_workflow_dispatches_renew_today():
+    from jjz_alert.service.jjz import renew_workflow
+
+    config = _make_config_with_renew_plate()
+    renew_status = _make_renew_status(
+        valid_end=(date.today() - timedelta(days=1)).isoformat(),
+        status=JJZStatusEnum.EXPIRED.value,
+    )
+    fake_account = MagicMock()
+    plate_renew_contexts = {"京A12345": ({"data": {}}, fake_account, renew_status)}
+
+    with patch.object(
+        renew_workflow.config_manager, "load_config", return_value=config
+    ), patch.object(
+        renew_workflow.JJZService,
+        "get_multiple_status_with_context",
+        new=AsyncMock(return_value=({}, plate_renew_contexts)),
+    ), patch(
+        "jjz_alert.service.jjz.renew_trigger.schedule_renew",
+        new=AsyncMock(),
+    ) as mock_schedule:
+        await renew_workflow.run_renew_only_workflow()
+
+        mock_schedule.assert_awaited_once()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_run_renew_only_workflow_skips_when_no_renew_plates():
+    from jjz_alert.service.jjz import renew_workflow
+
+    config = AppConfig()  # 无 plates
+
+    with patch.object(
+        renew_workflow.config_manager, "load_config", return_value=config
+    ), patch(
+        "jjz_alert.service.jjz.renew_trigger.schedule_renew",
+        new=AsyncMock(),
+    ) as mock_schedule:
+        await renew_workflow.run_renew_only_workflow()
+
+        mock_schedule.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_run_renew_only_workflow_no_pushes_to_status_endpoints():
+    """验证仅续办工作流不调用 push_jjz_status / push_jjz_reminder"""
+    from jjz_alert.service.jjz import renew_workflow
+
+    config = _make_config_with_renew_plate()
+    renew_status = _make_renew_status(valid_end=date.today().isoformat())
+    fake_account = MagicMock()
+    plate_renew_contexts = {"京A12345": ({"data": {}}, fake_account, renew_status)}
+
+    with patch.object(
+        renew_workflow.config_manager, "load_config", return_value=config
+    ), patch.object(
+        renew_workflow.JJZService,
+        "get_multiple_status_with_context",
+        new=AsyncMock(return_value=({}, plate_renew_contexts)),
+    ), patch(
+        "jjz_alert.service.notification.push_helpers.push_jjz_status",
+        new=AsyncMock(),
+    ) as mock_push_status, patch(
+        "jjz_alert.service.notification.push_helpers.push_jjz_reminder",
+        new=AsyncMock(),
+    ) as mock_push_reminder, patch(
+        "jjz_alert.service.jjz.renew_trigger.schedule_renew",
+        new=AsyncMock(),
+    ):
+        await renew_workflow.run_renew_only_workflow()
+
+        # 关键断言：兜底工作流不发状态/提醒推送
+        mock_push_status.assert_not_called()
+        mock_push_reminder.assert_not_called()


### PR DESCRIPTION
## Summary

- **触发模型重构**：从独立 00:00 cron 改为 remind 查询后事件驱动；按车牌决策 RENEW_TODAY / RENEW_TOMORROW / SKIP / PENDING / NOT_AVAILABLE，异步派发并复用 stateList 响应。
- **错峰与多账户**：threading.Lock + 拟人化随机延迟（默认 30~180s）保证跨 loop 串行；plate_contexts 三元组绑定 (response_data, account, 六环外最新 status)，避免多账户 token/status 错配。
- **BREAKING 配置**：移除 \`global.auto_renew.time_window_start / time_window_end\`，新增 \`min_delay_seconds\` / \`max_delay_seconds\`；旧字段保留时输出 WARN 不阻塞。
- **凌晨兜底**：remind 关或 remind.times 不含凌晨时刻时注册 00:30 cron 跑仅决策派发的独立工作流（不推送状态通知），确保 0 点放号后能续办。
- **配套**：决策器（\`renew_decider.py\`）、派发器（\`renew_trigger.py\`）、独立工作流（\`renew_workflow.py\`）三个新模块；删除 \`run_auto_renew_check\` / \`should_renew\` / \`calculate_random_delay\`；新增 OpenSpec 变更产出物。

## Test plan

- [x] \`pytest\` 全套件 816 passed, 12 skipped（含决策矩阵 12 用例 + 派发器集成测试 + 多账户上下文测试 + schedule_jobs 调度行为测试）
- [x] \`openspec-cn validate auto-renew-event-driven\` 通过
- [x] codex review 9 轮迭代，最终 clear（无 actionable bugs）
- [ ] 实机验证：23:55 触发场景①（明日缺）；白天触发场景②（已过期）；多账户车牌使用各自 token 续办
- [ ] 升级用户验证：旧 \`time_window_*\` 字段保留时启动 WARN 不阻塞、其他配置不丢失
- [ ] remind 关闭但 auto_renew 启用配置实机验证 00:30 兜底不发状态推送

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the auto-renew execution model and scheduling, adds new async dispatch/concurrency locking, and introduces a breaking config change; mistakes could lead to missed renewals or unexpected notification behavior.
> 
> **Overview**
> **Auto-renew is refactored from a standalone midnight cron into an event-driven flow triggered by the existing `remind` query workflow.** A new `renew_decider` returns explicit outcomes (`RENEW_TODAY`/`RENEW_TOMORROW`/`PENDING`/`NOT_AVAILABLE`/`SKIP`), and `jjz_push_service` now uses this to fire-and-forget `schedule_renew` tasks and **suppress conflicting “please renew” reminders** when a renewal has been dispatched.
> 
> **Renew dispatching is centralized in `renew_trigger.schedule_renew`**, adding per-plate random delay (`min_delay_seconds`~`max_delay_seconds`), a cross-thread/event-loop global `threading.Lock` to serialize renewal API chains, and reuse of the existing Redis dedup key. **`JJZService` now exposes `get_multiple_status_with_context`** to return per-plate renewal contexts `(raw response_data, account, latest six-ring-outer status)` to prevent multi-account/token mixups.
> 
> **BREAKING config update:** `global.auto_renew.time_window_start/end` are deprecated/ignored (warned) and replaced with `min_delay_seconds/max_delay_seconds`, with updated parsing/validation and example config. The old `run_auto_renew_check`/`should_renew`/window-based delay logic and the dedicated auto-renew cron registration are removed; a **00:30 fallback cron** is added to run a renew-only workflow when no post-midnight `remind` time exists. Tests are updated/added to cover config migration warnings, context selection, dispatcher serialization, decision matrix, and fallback scheduling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6d857f66143695a7f42985d9563ce5dcceec9f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->