### PR TITLE
fix: 修复续办防重复 Redis 操作 import 错误

### DIFF
--- a/jjz_alert/service/jjz/auto_renew_service.py
+++ b/jjz_alert/service/jjz/auto_renew_service.py
@@ -393,7 +393,10 @@ class AutoRenewService:
             key = f"auto_renew:{plate}:{date.today().isoformat()}"
             val = await redis_ops.get(key)
             return val is not None
-        except Exception:
+        except Exception as e:
+            # 不让异常阻断续办流程，但要可见——历史上 ImportError
+            # 静默吞掉造成防重失效长期未被发现
+            logger.warning(f"读取续办防重复记录失败 plate={plate}: {e}")
             return False
 
     async def _mark_renewed_today(self, plate: str):

--- a/jjz_alert/service/jjz/auto_renew_service.py
+++ b/jjz_alert/service/jjz/auto_renew_service.py
@@ -388,20 +388,20 @@ class AutoRenewService:
 
     async def _has_renewed_today(self, plate: str) -> bool:
         try:
-            from jjz_alert.config.redis.operations import redis_get
+            from jjz_alert.config.redis.operations import redis_ops
 
             key = f"auto_renew:{plate}:{date.today().isoformat()}"
-            val = await redis_get(key)
+            val = await redis_ops.get(key)
             return val is not None
         except Exception:
             return False
 
     async def _mark_renewed_today(self, plate: str):
         try:
-            from jjz_alert.config.redis.operations import redis_set
+            from jjz_alert.config.redis.operations import redis_ops
 
             key = f"auto_renew:{plate}:{date.today().isoformat()}"
-            await redis_set(key, "1", ttl=86400)
+            await redis_ops.set(key, "1", ttl=86400)
         except Exception as e:
             logger.warning(f"写入续办防重复记录失败: {e}")
 

--- a/jjz_alert/service/jjz/renew_trigger.py
+++ b/jjz_alert/service/jjz/renew_trigger.py
@@ -37,7 +37,10 @@ async def _has_renewed_today(plate: str) -> bool:
 
         key = f"auto_renew:{plate}:{date.today().isoformat()}"
         return (await redis_ops.get(key)) is not None
-    except Exception:
+    except Exception as e:
+        # 不让异常阻断派发流程，但要可见——历史上 ImportError
+        # 静默吞掉造成防重失效长期未被发现
+        logger.warning("[renew] 读取防重复记录失败 plate=%s: %s", plate, e)
         return False
 
 

--- a/jjz_alert/service/jjz/renew_trigger.py
+++ b/jjz_alert/service/jjz/renew_trigger.py
@@ -33,10 +33,10 @@ RENEW_GLOBAL_LOCK = threading.Lock()
 
 async def _has_renewed_today(plate: str) -> bool:
     try:
-        from jjz_alert.config.redis.operations import redis_get
+        from jjz_alert.config.redis.operations import redis_ops
 
         key = f"auto_renew:{plate}:{date.today().isoformat()}"
-        return (await redis_get(key)) is not None
+        return (await redis_ops.get(key)) is not None
     except Exception:
         return False
 

--- a/tests/unit/service/test_auto_renew.py
+++ b/tests/unit/service/test_auto_renew.py
@@ -357,40 +357,35 @@ class TestRenewDedupRedisOps:
         from jjz_alert.config.redis import operations as ops_module
 
         service = AutoRenewService()
+        expected_key = f"auto_renew:京A12345:{date.today().isoformat()}"
         with patch.object(
             ops_module.redis_ops, "get", new=AsyncMock(return_value="1")
         ) as mock_get:
             result = await service._has_renewed_today("京A12345")
         assert result is True
-        mock_get.assert_awaited_once()
-        called_key = mock_get.await_args.args[0]
-        assert called_key.startswith("auto_renew:京A12345:")
+        mock_get.assert_awaited_once_with(expected_key)
 
     @pytest.mark.asyncio
     async def test_auto_renew_service_mark_renewed_today_uses_redis_ops_set(self):
         from jjz_alert.config.redis import operations as ops_module
 
         service = AutoRenewService()
+        expected_key = f"auto_renew:京A12345:{date.today().isoformat()}"
         with patch.object(
             ops_module.redis_ops, "set", new=AsyncMock(return_value=True)
         ) as mock_set:
             await service._mark_renewed_today("京A12345")
-        mock_set.assert_awaited_once()
-        called_key = mock_set.await_args.args[0]
-        assert called_key.startswith("auto_renew:京A12345:")
-        assert mock_set.await_args.args[1] == "1"
-        assert mock_set.await_args.kwargs.get("ttl") == 86400
+        mock_set.assert_awaited_once_with(expected_key, "1", ttl=86400)
 
     @pytest.mark.asyncio
     async def test_renew_trigger_has_renewed_today_uses_redis_ops_get(self):
         from jjz_alert.config.redis import operations as ops_module
         from jjz_alert.service.jjz import renew_trigger
 
+        expected_key = f"auto_renew:京A12345:{date.today().isoformat()}"
         with patch.object(
             ops_module.redis_ops, "get", new=AsyncMock(return_value=None)
         ) as mock_get:
             result = await renew_trigger._has_renewed_today("京A12345")
         assert result is False
-        mock_get.assert_awaited_once()
-        called_key = mock_get.await_args.args[0]
-        assert called_key.startswith("auto_renew:京A12345:")
+        mock_get.assert_awaited_once_with(expected_key)

--- a/tests/unit/service/test_auto_renew.py
+++ b/tests/unit/service/test_auto_renew.py
@@ -342,3 +342,55 @@ class TestScheduleRenew:
 
         assert max_concurrent == 1
         assert len(order) == 4
+
+
+@pytest.mark.unit
+class TestRenewDedupRedisOps:
+    """续办当日防重 Redis key 接口契约测试
+
+    防回归：`auto_renew_service` 与 `renew_trigger` 必须使用 `redis_ops.get` /
+    `redis_ops.set`，而不是不存在的 `redis_get` / `redis_set` 模块级函数。
+    """
+
+    @pytest.mark.asyncio
+    async def test_auto_renew_service_has_renewed_today_uses_redis_ops_get(self):
+        from jjz_alert.config.redis import operations as ops_module
+
+        service = AutoRenewService()
+        with patch.object(
+            ops_module.redis_ops, "get", new=AsyncMock(return_value="1")
+        ) as mock_get:
+            result = await service._has_renewed_today("京A12345")
+        assert result is True
+        mock_get.assert_awaited_once()
+        called_key = mock_get.await_args.args[0]
+        assert called_key.startswith("auto_renew:京A12345:")
+
+    @pytest.mark.asyncio
+    async def test_auto_renew_service_mark_renewed_today_uses_redis_ops_set(self):
+        from jjz_alert.config.redis import operations as ops_module
+
+        service = AutoRenewService()
+        with patch.object(
+            ops_module.redis_ops, "set", new=AsyncMock(return_value=True)
+        ) as mock_set:
+            await service._mark_renewed_today("京A12345")
+        mock_set.assert_awaited_once()
+        called_key = mock_set.await_args.args[0]
+        assert called_key.startswith("auto_renew:京A12345:")
+        assert mock_set.await_args.args[1] == "1"
+        assert mock_set.await_args.kwargs.get("ttl") == 86400
+
+    @pytest.mark.asyncio
+    async def test_renew_trigger_has_renewed_today_uses_redis_ops_get(self):
+        from jjz_alert.config.redis import operations as ops_module
+        from jjz_alert.service.jjz import renew_trigger
+
+        with patch.object(
+            ops_module.redis_ops, "get", new=AsyncMock(return_value=None)
+        ) as mock_get:
+            result = await renew_trigger._has_renewed_today("京A12345")
+        assert result is False
+        mock_get.assert_awaited_once()
+        called_key = mock_get.await_args.args[0]
+        assert called_key.startswith("auto_renew:京A12345:")


### PR DESCRIPTION
## Summary

- v2.4.0 在 mac-mini 生产部署后，每次 remind 触发续办派发都会出现 WARNING：
  ```
  [WARNING] 写入续办防重复记录失败: cannot import name 'redis_set' from 'jjz_alert.config.redis.operations'
  ```
- 原因：`auto_renew_service` 与 `renew_trigger` 三处都 import 了不存在的模块级函数 `redis_get` / `redis_set`；ImportError 被 try/except 吞掉后表现为：
  - \`_has_renewed_today\` 永远返回 False（防重 key 永远查不到）
  - \`_mark_renewed_today\` 永远 WARNING + 跳过写入
- 修法：改用 `from jjz_alert.config.redis.operations import redis_ops` + `redis_ops.get(key)` / `redis_ops.set(key, "1", ttl=86400)`

## 影响范围

预先存在的 bug（v2.3.x 时代就有），但事件驱动续办（v2.4.0）每次 remind 都会派发，使 WARNING 在生产高频出现暴露问题。

**真实功能影响有限**：\`stateList.sfyecbzxx\`（待审记录）作为兜底，重复决策时 \`decide\` 返回 \`PENDING\` 跳过；所以历史上没有真正多次办理。修复后恢复 Redis fast-path 短路，减少不必要的二次决策。

## 测试

- 新增 `TestRenewDedupRedisOps`（3 个用例）：验证三处调用都使用 `redis_ops.get` / `redis_ops.set` 接口，并断言 key 格式 / value / ttl 参数；未来再写错 import 名会立即测试失败
- 完整套件 819 passed, 12 skipped
- `black --check` 通过

## Test plan

- [x] `pytest` 全套件全绿
- [x] `tox -e format-check` 通过
- [ ] 部署到 mac-mini 后观察 \`docker logs\` 不再出现 \`写入续办防重复记录失败\` WARNING

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk bugfix that corrects Redis dedup reads/writes and adds warning logs/tests; behavior change is limited to making the existing dedup key actually work and surfacing Redis/import failures.
> 
> **Overview**
> Fixes auto-renew *same-day dedup* by switching the Redis calls in `auto_renew_service` and `renew_trigger` from nonexistent `redis_get`/`redis_set` imports to `redis_ops.get`/`redis_ops.set`.
> 
> Also makes dedup read failures visible by logging the caught exception (previously swallowed), and adds unit tests (`TestRenewDedupRedisOps`) to lock in the `redis_ops` API usage plus key format and TTL to prevent regressions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19d4d84c2e14a175b5f50ac4bd98b87e36696037. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->