### PR TITLE
ci(docker): 多架构原生 runner 构建 + tag 自动 release

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -99,8 +99,8 @@ jobs:
 
       - uses: docker/setup-buildx-action@v4
 
+      # 无条件登录：push 路径需要写，verify 路径需要从 registry 读 cache
       - name: Log into GHCR
-        if: needs.setup.outputs.should_push == 'true'
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -210,6 +210,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      packages: read
       security-events: write
     steps:
       - name: Cache Trivy DB
@@ -219,6 +220,13 @@ jobs:
           key: trivy-db-${{ runner.os }}-${{ github.run_id }}
           restore-keys: |
             trivy-db-${{ runner.os }}-
+
+      - name: Log into GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       # 漏洞发现不阻断流水线（exit-code=0），但扫描器自身失败仍会让 step 失败
       - name: Run Trivy

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -2,9 +2,10 @@ name: Docker Image Build
 
 on:
   push:
-    branches: [ '**' ]
+    branches: ['**']
+    tags: ['v*']
   pull_request:
-    branches: [ 'master']
+    branches: ['master']
   workflow_dispatch:
     inputs:
       version:
@@ -12,79 +13,253 @@ on:
         required: true
         type: string
 
+env:
+  REGISTRY: ghcr.io
+
 jobs:
-  build:
+  setup:
     runs-on: ubuntu-latest
-    # 为 dependabot 分支跳过构建，避免权限问题
     if: ${{ !startsWith(github.actor, 'dependabot') }}
+    permissions: {}
+    outputs:
+      should_push: ${{ steps.cfg.outputs.should_push }}
+      is_tag: ${{ steps.cfg.outputs.is_tag }}
+      is_master: ${{ steps.cfg.outputs.is_master }}
+      version: ${{ steps.cfg.outputs.version }}
+      image: ${{ steps.cfg.outputs.image }}
+    steps:
+      - id: cfg
+        env:
+          GH_REF: ${{ github.ref }}
+          GH_EVENT: ${{ github.event_name }}
+          GH_REPO: ${{ github.repository }}
+          GH_SHA: ${{ github.sha }}
+          DISPATCH_VERSION: ${{ inputs.version }}
+        run: |
+          IMAGE_LOWER="${GH_REPO,,}"
+          IMAGE="${{ env.REGISTRY }}/${IMAGE_LOWER}"
+          IS_TAG=false
+          IS_MASTER=false
+          SHOULD_PUSH=false
+
+          # 是否在 master 分支上（独立判断，覆盖 push 与 dispatch 两种触发）
+          if [[ "$GH_REF" == "refs/heads/master" ]]; then
+            IS_MASTER=true
+          fi
+
+          if [[ "$GH_REF" == refs/tags/* ]]; then
+            RAW="${GH_REF#refs/tags/}"
+            SHOULD_PUSH=true
+            IS_TAG=true
+          elif [[ "$GH_EVENT" == "workflow_dispatch" ]]; then
+            RAW="$DISPATCH_VERSION"
+            SHOULD_PUSH=true
+          elif [[ "$IS_MASTER" == "true" ]]; then
+            RAW="$GH_SHA"
+            SHOULD_PUSH=true
+          else
+            RAW="${GH_REF#refs/heads/}"
+          fi
+
+          # Docker 镜像 tag 仅允许 [A-Za-z0-9_.-]，且不能以 . 或 - 起头；
+          # 其它字符（含 semver build metadata 中的 +、分支里的 /）一律替换为 -
+          SANITIZED="${RAW//[!a-zA-Z0-9_.-]/-}"
+          while [[ "$SANITIZED" == [.-]* ]]; do
+            SANITIZED="${SANITIZED:1}"
+          done
+          [[ -z "$SANITIZED" ]] && SANITIZED="unknown"
+          VERSION="${SANITIZED:0:128}"
+
+          {
+            echo "image=$IMAGE"
+            echo "version=$VERSION"
+            echo "is_tag=$IS_TAG"
+            echo "is_master=$IS_MASTER"
+            echo "should_push=$SHOULD_PUSH"
+          } >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: setup
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            arch: amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            arch: arm64
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
       packages: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: docker/setup-buildx-action@v4
+
+      - name: Log into GHCR
+        if: needs.setup.outputs.should_push == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build (push by digest)
+        if: needs.setup.outputs.should_push == 'true'
+        id: build_push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.github-actions
+          platforms: ${{ matrix.platform }}
+          build-args: |
+            VERSION=${{ needs.setup.outputs.version }}
+          outputs: type=image,name=${{ needs.setup.outputs.image }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=registry,ref=${{ needs.setup.outputs.image }}:buildcache-${{ matrix.arch }}
+          cache-to: type=registry,ref=${{ needs.setup.outputs.image }}:buildcache-${{ matrix.arch }},mode=max
+          provenance: mode=max
+          sbom: true
+
+      - name: Build (verify only)
+        if: needs.setup.outputs.should_push != 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.github-actions
+          platforms: ${{ matrix.platform }}
+          build-args: |
+            VERSION=${{ needs.setup.outputs.version }}
+          push: false
+          load: false
+          cache-from: type=registry,ref=${{ needs.setup.outputs.image }}:buildcache-${{ matrix.arch }}
+          provenance: false
+          sbom: false
+
+      - name: Export digest
+        if: needs.setup.outputs.should_push == 'true'
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build_push.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        if: needs.setup.outputs.should_push == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: digests-${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    needs: [setup, build]
+    if: needs.setup.outputs.should_push == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      image_ref: ${{ steps.manifest.outputs.image_ref }}
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - uses: docker/setup-buildx-action@v4
+
+      - name: Log into GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create manifest
+        id: manifest
+        working-directory: /tmp/digests
+        env:
+          IMG: ${{ needs.setup.outputs.image }}
+          VER: ${{ needs.setup.outputs.version }}
+          IS_TAG: ${{ needs.setup.outputs.is_tag }}
+          IS_MASTER: ${{ needs.setup.outputs.is_master }}
+        run: |
+          tag_args=("-t" "$IMG:$VER")
+          if [[ "$IS_TAG" == "true" || "$IS_MASTER" == "true" ]]; then
+            tag_args+=("-t" "$IMG:latest")
+          fi
+
+          src_args=()
+          for f in *; do
+            src_args+=("$IMG@sha256:$f")
+          done
+
+          docker buildx imagetools create "${tag_args[@]}" "${src_args[@]}"
+          echo "image_ref=$IMG:$VER" >> "$GITHUB_OUTPUT"
+
+      - name: Inspect manifest
+        run: docker buildx imagetools inspect "${{ steps.manifest.outputs.image_ref }}"
+
+  scan:
+    needs: [setup, merge]
+    if: needs.setup.outputs.should_push == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
       security-events: write
     steps:
-    - uses: actions/checkout@v6
+      - name: Cache Trivy DB
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/trivy
+          key: trivy-db-${{ runner.os }}-${{ github.run_id }}
+          restore-keys: |
+            trivy-db-${{ runner.os }}-
 
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v4
-      with:
-        driver-opts: |
-          image=moby/buildkit:v0.12.0
+      # 漏洞发现不阻断流水线（exit-code=0），但扫描器自身失败仍会让 step 失败
+      - name: Run Trivy
+        uses: aquasecurity/trivy-action@0.36.0
+        with:
+          image-ref: ${{ needs.merge.outputs.image_ref }}
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          exit-code: '0'
+          cache: 'true'
 
-    - name: Log into GitHub Container Registry
-      run: echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Upload SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: 'trivy-results.sarif'
+          category: 'trivy-scan'
 
-    - name: Determine version and tags
-      run: |
-        # 获取分支名，移除 refs/heads/ 前缀
-        BRANCH_NAME=${GITHUB_REF#refs/heads/}
-        # 将分支名中的特殊字符替换为连字符，确保标签有效
-        SAFE_BRANCH_NAME=$(echo "$BRANCH_NAME" | sed 's/[^a-zA-Z0-9.-]/-/g')
-        
-        if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-          VERSION="${{ inputs.version }}"
-        elif [ "$BRANCH_NAME" = "master" ]; then
-          VERSION="${{ github.sha }}"
-        else
-          VERSION="$SAFE_BRANCH_NAME"
-        fi
-        echo "IMAGE_VERSION=$VERSION" >> $GITHUB_ENV
-        echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
+  release:
+    needs: [setup, merge]
+    if: needs.setup.outputs.is_tag == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
-    - name: Build and push Docker image (multi-arch)
-      run: |
-        PLATFORMS=linux/arm64,linux/amd64
-        DOCKER_IMAGE=ghcr.io/$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
-        VERSION=${IMAGE_VERSION:-latest}
-        BRANCH_NAME=${BRANCH_NAME:-unknown}
-        echo "DOCKER_IMAGE_LOWERCASE=$DOCKER_IMAGE" >> $GITHUB_ENV
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
+          generate_release_notes: true
+          body: |
+            ## Docker 镜像
 
-        if [ "$BRANCH_NAME" = "master" ]; then
-          docker buildx build --platform $PLATFORMS \
-            -f Dockerfile.github-actions \
-            -t $DOCKER_IMAGE:latest \
-            -t $DOCKER_IMAGE:${VERSION} \
-            --cache-from type=gha \
-            --cache-to type=gha,mode=max \
-            --push .
-        else
-          docker buildx build --platform $PLATFORMS \
-            -f Dockerfile.github-actions \
-            -t $DOCKER_IMAGE:${VERSION} \
-            --cache-from type=gha \
-            --cache-to type=gha,mode=max \
-            --push .
-        fi
+            支持架构：`linux/amd64`、`linux/arm64`
 
-    - name: Run security scan
-      uses: aquasecurity/trivy-action@master
-      with:
-        image-ref: ${{ env.DOCKER_IMAGE_LOWERCASE }}:${{ env.IMAGE_VERSION }}
-        format: 'sarif'
-        output: 'trivy-results.sarif'
-
-    - name: Upload Trivy scan results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@v4
-      if: always()
-      with:
-        sarif_file: 'trivy-results.sarif'
-        category: 'trivy-scan' 
+            ```sh
+            docker pull ${{ needs.setup.outputs.image }}:${{ needs.setup.outputs.version }}
+            docker pull ${{ needs.setup.outputs.image }}:latest
+            ```

--- a/Dockerfile.github-actions
+++ b/Dockerfile.github-actions
@@ -1,60 +1,31 @@
 # syntax=docker/dockerfile:1.7-labs
 
-# 预下载 wheels（在构建机平台执行，避免 ARM64 下网络与解析开销）
-FROM --platform=$BUILDPLATFORM python:3.14-slim AS wheelhouse
-
-ENV PIP_DISABLE_PIP_VERSION_CHECK=1
-ENV PIP_NO_INPUT=1
-WORKDIR /wheels
-COPY requirements-prod.txt ./
-RUN --mount=type=cache,id=pip-cache,target=/root/.cache/pip \
-    pip install --upgrade pip && \
-    pip download --only-binary=:all: \
-      --implementation cp --python-version 314 --abi cp314 \
-      --platform manylinux_2_17_x86_64 \
-      --dest /wheels/x86_64 \
-      -r requirements-prod.txt && \
-    pip download --only-binary=:all: \
-      --implementation cp --python-version 314 --abi cp314 \
-      --platform manylinux_2_17_aarch64 \
-      --dest /wheels/aarch64 \
-      -r requirements-prod.txt
-
-# 最终运行镜像
 FROM python:3.14-slim
 
-# 设置工作目录与环境
 WORKDIR /app
-ENV PYTHONUNBUFFERED=1
-ENV PYTHONDONTWRITEBYTECODE=1
-ENV TZ=Asia/Shanghai
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    TZ=Asia/Shanghai \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PIP_NO_INPUT=1 \
+    UV_LINK_MODE=copy \
+    UV_SYSTEM_PYTHON=1
+
 ARG VERSION=latest
 ENV VERSION=${VERSION}
-ENV PIP_DISABLE_PIP_VERSION_CHECK=1
-ENV PIP_NO_INPUT=1
-# 声明来自 buildx 的自动构建参数
-ARG TARGETARCH
 
-# 复制依赖与离线 wheels
+COPY --from=ghcr.io/astral-sh/uv:0.11.8 /uv /usr/local/bin/uv
+
 COPY requirements-prod.txt ./
-COPY --from=wheelhouse /wheels /wheels
+RUN --mount=type=cache,id=uv-cache,target=/root/.cache/uv \
+    uv pip install --system -r requirements-prod.txt
 
-# 按平台选择对应 wheels 目录并离线安装
-RUN --mount=type=cache,id=pip-cache,target=/root/.cache/pip \
-    if [ "$TARGETARCH" = "arm64" ]; then \
-      WHEELDIR=/wheels/aarch64; \
-    else \
-      WHEELDIR=/wheels/x86_64; \
-    fi; \
-    echo "Using wheel dir: $WHEELDIR for TARGETARCH=$TARGETARCH"; \
-    pip install --no-index --find-links=$WHEELDIR -r requirements-prod.txt
+COPY main.py rest_api.py cli_tools.py ./
+COPY jjz_alert/ ./jjz_alert/
+COPY modules/ ./modules/
 
-# 复制项目文件
-COPY . .
-
-# 健康检查
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD python -c "import os; assert os.path.exists('/app/main.py')" || exit 1
 
-# 启动命令
-CMD ["python", "main.py"] 
+CMD ["python", "main.py"]


### PR DESCRIPTION
## Summary

- 拆 matrix 到原生 ARM/x64 runner，消除 QEMU 模拟（ARM64 pip install 从 ~130s 降到原生速度）
- master/tag/dispatch 走 push-by-digest + manifest 合并；feature 分支只做构建验证不 push
- 新增 tag (\`v*\`) 推送时自动创建 GitHub Release（softprops/action-gh-release@v3，附 docker pull 指令）
- Dockerfile 简化：删除 wheelhouse 跨平台预下载阶段，pip → uv（钉 0.11.8）
- Trivy 独立 job + 固定 0.36.0 + DB 缓存 + \`exit-code=0\` 区分 "扫描器故障" 与 "发现漏洞"
- push 路径启用 provenance/sbom；按 arch 隔离 registry cache；tag/branch 名规范化为合法 Docker tag
- setup job 收紧默认权限为 \`permissions: {}\`

## Test plan

- [ ] feature 分支 push：amd64 + arm64 并行 verify build，不 push 到 GHCR
- [ ] master push：matrix → push-by-digest → 合并 manifest → \`:sha\` + \`:latest\` 双 tag → Trivy 扫描
- [ ] tag (\`v*\`) push：上述全流程 + 自动 GitHub Release（带 docker pull 指令）
- [ ] workflow_dispatch on master：仍能打 \`:latest\`（修复了之前的回归）
- [ ] 异常 tag 名（含 \`+\`、\`/\`、前导 \`.-\`）：sanitized version 在 release 通知里指向真实存在的镜像 tag
- [ ] Trivy 漏洞发现不阻断流水线，但扫描器自身故障会让 step 失败

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI now changes when and how images are published (digest-based pushes, manifest creation, and tag-driven releases), so misconfiguration could affect image tagging/publishing and security scan reporting.
> 
> **Overview**
> Reworks the Docker image GitHub Actions workflow to split into `setup`/per-arch `build`/`merge`/`scan`/`release` jobs, building `linux/amd64` and `linux/arm64` on native runners, pushing by digest, and then creating a multi-arch manifest tagged with a sanitized version (and `latest` on `master`/tags). Feature branches now only *verify-build* without pushing, while `master`, `workflow_dispatch`, and `v*` tags publish to GHCR, generate SBOM/provenance, and run Trivy SARIF scanning with cached DB and non-blocking vulnerability findings.
> 
> Adds automatic GitHub Release creation on `v*` tag pushes with generated notes and Docker pull instructions.
> 
> Updates `Dockerfile.github-actions` to drop the wheelhouse pre-download stage and switch dependency install to pinned `uv` (`ghcr.io/astral-sh/uv:0.11.8`) with build cache, and narrows the file copy set to the app entrypoints and module directories.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29f822fd565199f0a90b46c1ec4d805eccfde2e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->