### PR TITLE
fix(ci): trivy-action tag 应带 v 前缀

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -230,7 +230,7 @@ jobs:
 
       # 漏洞发现不阻断流水线（exit-code=0），但扫描器自身失败仍会让 step 失败
       - name: Run Trivy
-        uses: aquasecurity/trivy-action@0.36.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: ${{ needs.merge.outputs.image_ref }}
           format: 'sarif'


### PR DESCRIPTION
## Summary

合并 #58 后 master 的 docker-image workflow 在 \`scan\` job 失败：

> Unable to resolve action \`aquasecurity/trivy-action@0.36.0\`, unable to find version \`0.36.0\`

\`aquasecurity/trivy-action\` 的 release tag 是 \`v0.36.0\`，不是 \`0.36.0\`。

## Test plan

- [x] actionlint pass
- [ ] 合并后下次 master push 的 scan job 应能正常执行

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a one-line CI workflow fix that only changes the referenced GitHub Action version tag to a valid release, restoring the `scan` job execution.
> 
> **Overview**
> Fixes the Docker image workflow `scan` job by updating the Trivy GitHub Action reference from `aquasecurity/trivy-action@0.36.0` to the correct `@v0.36.0`, preventing action resolution failures and allowing SARIF upload to proceed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d53d9018f113a84c456e359f2a77c6560fa96d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->